### PR TITLE
Fix consistency issues across skill documentation

### DIFF
--- a/skills/agent-authoring/SKILL.md
+++ b/skills/agent-authoring/SKILL.md
@@ -7,6 +7,18 @@ allowed-tools:
   - Glob
   - Bash
   - AskUserQuestion
+model: sonnet
+---
+
+## Reference Files
+
+Advanced agent authoring guidance:
+
+- [design-patterns.md](design-patterns.md) - Proven agent patterns with examples
+- [examples.md](examples.md) - Complete agent examples with analysis
+- [agent-decision-guide.md](agent-decision-guide.md) - Deciding when to use agents vs skills vs commands
+- [comparison-with-official.md](comparison-with-official.md) - Comparison with Anthropic's official agents
+
 ---
 
 ## About Agents
@@ -406,6 +418,20 @@ For detailed standards and validation:
 - **Validation** - Use `/audit-agent` command
 
 See `audit-coordinator` skill for comprehensive standards.
+
+## Related Skills
+
+This skill is part of the authoring skill family:
+
+- **agent-authoring** - Guide for creating agents (this skill)
+- **skill-authoring** - Guide for creating skills
+- **command-authoring** - Guide for creating commands
+- **output-style-authoring** - Guide for creating output styles
+
+For validation, use the corresponding audit skills:
+
+- **agent-audit** - Validate agent configurations
+- **audit-coordinator** - Comprehensive multi-faceted audits
 
 ## Quick Start Checklist
 

--- a/skills/command-authoring/SKILL.md
+++ b/skills/command-authoring/SKILL.md
@@ -7,6 +7,7 @@ allowed-tools:
   - Glob
   - Bash
   - AskUserQuestion
+model: sonnet
 ---
 
 ## Reference Files
@@ -185,6 +186,20 @@ See [command-examples.md](command-examples.md) for complete examples with analys
 6. **Make purpose immediately clear** - no guessing
 7. **Optional arguments are better** - provide defaults
 8. **Start simple** - can always add documentation later
+
+## Related Skills
+
+This skill is part of the authoring skill family:
+
+- **agent-authoring** - Guide for creating agents
+- **skill-authoring** - Guide for creating skills
+- **command-authoring** - Guide for creating commands (this skill)
+- **output-style-authoring** - Guide for creating output styles
+
+For validation, use the corresponding audit skills:
+
+- **command-audit** - Validate command configurations
+- **audit-coordinator** - Comprehensive multi-faceted audits
 
 ## Quick Start Checklist
 

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow
-description: Automates complete git workflows including branch management, atomic commits with formatted messages, history cleanup, and PR creation. Use when the user wants to commit/make commits, push to remote, create/open a PR, clean up commits, create branches, write commit messages, mentions atomic commits, git workflow, git best practices, or needs help organizing git changes. Also use when user is on main/master with uncommitted changes (suggest branching), has messy commit history to clean up before pushing, wants to squash or reorder commits, or needs help creating pull requests.
+description: Automates complete git workflows including branch management, atomic commits with formatted messages, history cleanup, and PR creation. Use when the user wants to commit/make commits, push to remote, create/open a PR, clean up commits, create branches, write commit messages, mentions atomic commits, git workflow, git best practices, or needs help organizing git changes. Also triggers when user is on main/master with uncommitted changes (suggest branching), has messy commit history to clean up before pushing, wants to squash or reorder commits, or needs help creating pull requests.
 allowed-tools: Read, Bash, AskUserQuestion, TodoWrite
 model: sonnet
 ---

--- a/skills/organize-folders/SKILL.md
+++ b/skills/organize-folders/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: organize-folders
 description: Provides guidance on organizing folder structures and file system layouts for any project. Use when planning project organization, reorganizing messy directories, setting up folder hierarchies, creating folder structures, designing directory layouts, organizing drafts and published content, structuring repositories, cleaning up file layouts, arranging files, or need help with folder structure or file organization. Helps with writing projects, code projects, document collections, or any file organization task. Provides guidance for creating appropriate folder structures, organizing versions, implementing simple systems, following user preferences.
-allowed-tools: [Read, Edit, Grep, Glob]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Folder Organization Guidance

--- a/skills/output-style-authoring/SKILL.md
+++ b/skills/output-style-authoring/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: output-style-authoring
-description: Guide for authoring output-styles that transform Claude's behavior and personality. Use when creating, writing, designing, building, reviewing, or improving output-styles, persona modes, role transformations, or behavior modifications. Helps design style files, choose when to keep coding instructions, write clear personas, and decide between output-styles, agents, and skills. Also use when asking how to create output-styles, what makes a good style, learning about style development, or understanding when to use output-styles. Expert in persona design, behavior transformation, and style best practices.
+description: Guide for authoring output-styles that transform Claude's behavior and personality. Use when creating, writing, designing, building, reviewing, or improving output-styles, persona modes, role transformations, or behavior modifications. Helps design style files, choose when to keep coding instructions, write clear personas, and decide between output-styles, agents, and skills. Also triggers when asking how to create output-styles, what makes a good style, learning about style development, or understanding when to use output-styles. Expert in persona design, behavior transformation, and style best practices.
 allowed-tools:
   - Read
   - Grep
   - Glob
   - Bash
   - AskUserQuestion
+model: sonnet
 ---
 
 ## Reference Files
@@ -28,6 +29,20 @@ allowed-tools:
 # Output-Style Authoring
 
 Guide for creating output-styles that transform Claude's behavior and personality.
+
+## Related Skills
+
+This skill is part of the authoring skill family:
+
+- **agent-authoring** - Guide for creating agents
+- **skill-authoring** - Guide for creating skills
+- **command-authoring** - Guide for creating commands
+- **output-style-authoring** - Guide for creating output styles (this skill)
+
+For validation, use the corresponding audit skills:
+
+- **output-style-audit** - Validate output-style configurations
+- **audit-coordinator** - Comprehensive multi-faceted audits
 
 ## Quick Start
 
@@ -115,7 +130,7 @@ See [anti-patterns.md](anti-patterns.md) #7 for more on this.
 
 ### Step 6: Write Description
 
-100-200 chars, explains what + when to use
+200-400 chars, explains what + when to use
 
 **Good:** "Clear, beginner-friendly documentation with examples"
 **Bad:** "Helps with writing" (too vague)

--- a/skills/process-pdfs/SKILL.md
+++ b/skills/process-pdfs/SKILL.md
@@ -375,16 +375,16 @@ with open("encrypted.pdf", "wb") as output:
 
 ## Quick Reference
 
-| Task               | Best Tool                                              | Command/Code                        |
-| ------------------ | ------------------------------------------------------ | ----------------------------------- |
-| Merge PDFs         | pypdf                                                  | `writer.add_page(page)`             |
-| Split PDFs         | pypdf                                                  | One page per file                   |
-| Extract text       | pdfplumber                                             | `page.extract_text()`               |
-| Extract tables     | pdfplumber                                             | `page.extract_tables()`             |
-| Create PDFs        | reportlab                                              | Canvas or Platypus                  |
-| Command line merge | qpdf                                                   | `qpdf --empty --pages ...`          |
-| OCR scanned PDFs   | pytesseract                                            | Convert to image first              |
-| Fill PDF forms     | pdf-lib or pypdf (see [forms.md](forms.md)) | See [forms.md](forms.md) |
+| Task               | Best Tool                                   | Command/Code               |
+| ------------------ | ------------------------------------------- | -------------------------- |
+| Merge PDFs         | pypdf                                       | `writer.add_page(page)`    |
+| Split PDFs         | pypdf                                       | One page per file          |
+| Extract text       | pdfplumber                                  | `page.extract_text()`      |
+| Extract tables     | pdfplumber                                  | `page.extract_tables()`    |
+| Create PDFs        | reportlab                                   | Canvas or Platypus         |
+| Command line merge | qpdf                                        | `qpdf --empty --pages ...` |
+| OCR scanned PDFs   | pytesseract                                 | Convert to image first     |
+| Fill PDF forms     | pdf-lib or pypdf (see [forms.md](forms.md)) | See [forms.md](forms.md)   |
 
 ## Troubleshooting
 

--- a/skills/skill-audit/SKILL.md
+++ b/skills/skill-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-audit
-description: Audits skills for discoverability and triggering effectiveness. Use when analyzing skill descriptions, checking trigger phrase coverage, validating progressive disclosure, reviewing SKILL.md structure, ensuring skills are discoverable, testing skill triggering, improving skill descriptions, or evaluating whether a skill will be invoked appropriately. Also triggers when user asks about skill best practices, wants to improve skill discovery, or needs help with skill structure.
+description: Audits skills for discoverability and triggering effectiveness. Use when analyzing skill descriptions, checking trigger phrase coverage, validating progressive disclosure, reviewing SKILL.md structure, ensuring skill discoverability, testing skill triggering, improving skill descriptions, or evaluating whether a skill will be invoked appropriately. Also triggers when user asks about skill best practices, wants to improve skill discoverability, or needs help with skill structure.
 allowed-tools: [Read, Glob, Grep, Bash]
 ---
 
@@ -160,7 +160,7 @@ Provide audit reports in this standardized structure:
 
 ## Summary
 
-{1-2 sentence overview of skill and discovery assessment}
+{1-2 sentence overview of skill and discoverability assessment}
 
 ## Discovery Score
 
@@ -238,7 +238,7 @@ Provide audit reports in this standardized structure:
 
 ## Priority Recommendations
 
-1. **Critical**: {must-fix for discovery}
+1. **Critical**: {must-fix for discoverability}
 2. **Important**: {should-fix for better triggering}
 3. **Nice-to-Have**: {polish improvements}
 

--- a/skills/skill-authoring/SKILL.md
+++ b/skills/skill-authoring/SKILL.md
@@ -1,7 +1,14 @@
 ---
 name: skill-authoring
-description: Guide for authoring effective skills. Use when creating, building, updating, designing, packaging, reviewing, evaluating, or improving skills that extend Claude's capabilities with specialized knowledge, workflows, or tool integrations. Helps with skill structure, SKILL.md frontmatter, progressive disclosure, resource organization (scripts/assets/reference files), initialization templates, validation, and packaging. Also use when asking how to create a skill, what makes a good skill, learning about skill development, or troubleshooting skill issues. Includes proven design patterns for workflows and output quality.
-allowed-tools: [Read, Write, Edit, Glob, Grep, Bash]
+description: Guide for authoring effective skills. Use when creating, building, updating, designing, packaging, reviewing, evaluating, or improving skills that extend Claude's capabilities with specialized knowledge, workflows, or tool integrations. Helps with skill structure, SKILL.md frontmatter, progressive disclosure, resource organization (scripts/assets/reference files), initialization templates, validation, and packaging. Also triggers when asking how to create a skill, what makes a good skill, learning about skill development, or troubleshooting skill issues. Includes proven design patterns for workflows and output quality.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+model: sonnet
 license: Complete terms in LICENSE.txt
 ---
 
@@ -14,6 +21,10 @@ This skill includes additional reference files:
 - [troubleshooting.md](troubleshooting.md) - Error solutions
 - [output-patterns.md](output-patterns.md) - Output quality patterns
 - [workflows.md](workflows.md) - Workflow patterns
+
+**Decision guides:**
+
+- [when-to-use-what.md](../../references/when-to-use-what.md) - Choosing between skills, agents, commands, and output-styles (shared)
 
 ---
 
@@ -335,3 +346,17 @@ See [complete-example.md](complete-example.md) for full `code-formatter` skill w
 - Validation and packaging
 
 Read when you want to see the complete skill authoring process.
+
+## Related Skills
+
+This skill is part of the authoring skill family:
+
+- **agent-authoring** - Guide for creating agents
+- **skill-authoring** - Guide for creating skills (this skill)
+- **command-authoring** - Guide for creating commands
+- **output-style-authoring** - Guide for creating output styles
+
+For validation, use the corresponding audit skills:
+
+- **skill-audit** - Validate skill configurations
+- **audit-coordinator** - Comprehensive multi-faceted audits


### PR DESCRIPTION
## Summary

Addresses GitHub issues #59, #47, #62, #64, and #23 to standardize skill documentation across the codebase.

### Quick Wins (Issues #59, #47, #62)

- **#59**: Fix description length guidance (100-200 → 200-400 chars) in output-style-authoring
- **#47**: Remove Edit tool from organize-folders (guidance-only skill)
- **#62**: Standardize skill-audit terminology (consistent use of "discoverability" vs "discovery")

### Multi-File Standardization (Issue #64)

- **#64**: Standardize "Also triggers when" phrasing across skills (skill-authoring, output-style-authoring, git-workflow)

### Authoring Skills Family Consistency (Issue #23)

All four authoring skills now have consistent structure:
- ✅ Added `model: sonnet` field to frontmatter
- ✅ Added "Reference Files" section (agent-authoring was missing this)
- ✅ Added "Related Skills" section showing family connections
- ✅ Converted skill-authoring allowed-tools to list format for consistency
- ✅ Added reference to shared when-to-use-what.md decision guide

## Files Modified (8)

- skills/agent-authoring/SKILL.md
- skills/command-authoring/SKILL.md
- skills/git-workflow/SKILL.md
- skills/organize-folders/SKILL.md
- skills/output-style-authoring/SKILL.md
- skills/skill-audit/SKILL.md
- skills/skill-authoring/SKILL.md
- skills/process-pdfs/SKILL.md (table formatting)

## Test Plan

- [ ] Verify all skill descriptions follow consistent patterns
- [ ] Verify authoring skills have Related Skills section
- [ ] Verify organize-folders no longer has Edit tool
- [ ] Verify skill-audit uses "discoverability" consistently
- [ ] Verify "Also triggers when" phrasing is standardized

## Closes

#59, #47, #62, #64

## Partially Addresses

#23 (authoring skills family consistency - fully addressed the structural consistency portion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)