### PR TITLE
Complete agent-authoring skill polish from issue #22

### DIFF
--- a/skills/agent-authoring/SKILL.md
+++ b/skills/agent-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-authoring
-description: Guide for authoring, designing, and building specialized AI agents. Use when creating, updating, reviewing, or improving agents that handle specific tasks with focused expertise. Helps design AGENT.md files, choose models (Sonnet/Haiku/Opus), define focus areas, configure tool restrictions, and decide between agents, skills, and commands. Expert in agent validation, best practices, and troubleshooting.
+description: Guide for authoring, designing, building, writing, and developing specialized AI agents. Use when creating, updating, reviewing, or improving agents that handle specific tasks with focused expertise. Helps design AGENT.md files, choose models (Sonnet/Haiku/Opus), define focus areas, configure tool restrictions, and decide between agents, skills, and commands. Expert in agent validation, best practices, and troubleshooting.
 allowed-tools:
   - Read
   - Grep
@@ -362,6 +362,8 @@ This will check:
 ## Agents vs Skills vs Commands
 
 Choosing the right customization type is critical. Each has distinct characteristics and use cases.
+
+**📄 See [agent-decision-guide.md](agent-decision-guide.md) for agent-specific decision framework**
 
 **📄 See [when-to-use-what.md](../../references/when-to-use-what.md) for detailed decision guide (shared)**
 


### PR DESCRIPTION
## Summary

Completes the remaining work from issue #22 to polish the agent-authoring skill:

- **Priority 2**: Added "writing" and "developing" trigger words to description for better discoverability
- **Priority 3**: Added explicit reference to agent-decision-guide.md in the "Agents vs Skills vs Commands" section

## Changes

- Line 3: Enhanced description with additional trigger verbs
- Line 366: Added agent-decision-guide.md reference for clearer navigation to decision resources

## Status

All 4 priorities from issue #22 are now complete:
- ✅ Priority 1: Model field & reference section (previously completed)
- ✅ Priority 2: Description enhancement (this PR)
- ✅ Priority 3: Agent-decision-guide integration (this PR)
- ✅ Priority 4: Cross-reference section (previously completed)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)