### PR TITLE
Remove non-functional tags field from SKILL.md frontmatter

### DIFF
--- a/skills/hook-audit/SKILL.md
+++ b/skills/hook-audit/SKILL.md
@@ -3,7 +3,6 @@ name: hook-audit
 description: Comprehensive audit of Claude Code hooks for correctness, safety, and performance. Use when reviewing, validating, or debugging hooks, checking JSON stdin handling, verifying exit codes (0=allow, 2=block), analyzing error handling, fixing hook failures, ensuring safe degradation, optimizing performance, or validating settings.json registration. Also triggers when user asks about hook best practices, wants to create a new hook, or needs help with hook configuration.
 allowed-tools: [Read, Grep, Glob, Bash]
 model: haiku
-tags: [audit, hooks, validation, security]
 ---
 
 ## Reference Files

--- a/skills/organize-folders/SKILL.md
+++ b/skills/organize-folders/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: organize-folders
 description: Provides guidance on organizing folder structures and file system layouts for any project. Use when planning project organization, reorganizing messy directories, setting up folder hierarchies, designing directory layouts, structuring repositories, cleaning up files, suggesting folder structures, establishing naming conventions, or when you need help with folder structure or file organization. Helps with writing projects, code projects, document collections, or any file organization task.
-tags: [organization, guidance, files, directories]
 allowed-tools: [Read, Grep, Glob]
 model: haiku
 ---

--- a/skills/output-style-audit/SKILL.md
+++ b/skills/output-style-audit/SKILL.md
@@ -3,7 +3,6 @@ name: output-style-audit
 description: Validates output-style persona definitions, behavior specifications, and keep-coding-instructions decisions. Use when auditing, reviewing, or improving output-styles, checking persona clarity, validating behavior concreteness, or verifying scope alignment (user vs project). Triggers when user asks about output-style best practices or needs help with persona definition.
 allowed-tools: [Read, Grep, Glob, Bash]
 model: sonnet
-tags: [validation, output-styles, audit, quality-assurance]
 ---
 
 ## Reference Files

--- a/skills/output-style-authoring/SKILL.md
+++ b/skills/output-style-authoring/SKILL.md
@@ -8,7 +8,6 @@ allowed-tools:
   - Bash
   - AskUserQuestion
 model: sonnet
-tags: [authoring, output-styles, guide, creation]
 ---
 
 ## Reference Files


### PR DESCRIPTION
## Summary

Removes the non-functional `tags` field from SKILL.md frontmatter in 4 skills. The `tags` field is not part of the official Claude Code specification and is silently ignored by the system.

## Changes

Removed `tags` field from:
- `skills/hook-audit/SKILL.md`
- `skills/organize-folders/SKILL.md`
- `skills/output-style-audit/SKILL.md`
- `skills/output-style-authoring/SKILL.md`

## Why

According to the [official Claude Code Skills documentation](https://code.claude.com/docs/en/skills), the only valid SKILL.md frontmatter fields are `name`, `description`, `allowed-tools`, and `model`. The `tags` field provides zero functionality and is documentation-only metadata that clutters the frontmatter.

## Impact

- **No functional impact** - Tags were never being used
- **Cleaner frontmatter** - Removes clutter and confusion
- **Standards compliance** - Aligns with official Claude Code specification

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)