### PR TITLE
Standardize statusline formatting to use spaces

### DIFF
--- a/statusline/biome.json
+++ b/statusline/biome.json
@@ -1,18 +1,9 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
-	"vcs": {
-		"enabled": true,
-		"clientKind": "git",
-		"useIgnoreFile": true
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true
-		}
-	},
-	"formatter": {
-		"enabled": true,
-		"indentStyle": "tab"
-	}
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+  "files": {
+    "includes": ["**/*", "!**/dist", "!**/node_modules"]
+  },
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "linter": { "enabled": true, "rules": { "recommended": true } },
+  "formatter": { "enabled": true, "indentStyle": "space" }
 }

--- a/statusline/package.json
+++ b/statusline/package.json
@@ -1,16 +1,16 @@
 {
-	"name": "claude-statusline",
-	"version": "1.0.0",
-	"type": "module",
-	"scripts": {
-		"build": "bun build src/index.ts --outfile=dist/index.js --target=node --format=esm --minify",
-		"lint": "biome check .",
-		"format": "biome format --write .",
-		"test": "bun test"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "*",
-		"@types/node": "*",
-		"typescript": "*"
-	}
+  "name": "claude-statusline",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "bun build src/index.ts --outfile=dist/index.js --target=node --format=esm --minify",
+    "lint": "biome check .",
+    "format": "biome format --write .",
+    "test": "bun test"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "*",
+    "@types/node": "*",
+    "typescript": "*"
+  }
 }

--- a/statusline/src/config-reader.ts
+++ b/statusline/src/config-reader.ts
@@ -3,137 +3,137 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 export interface ConfigCounts {
-	claudeMdCount: number;
-	rulesCount: number;
-	mcpCount: number;
-	hooksCount: number;
+  claudeMdCount: number;
+  rulesCount: number;
+  mcpCount: number;
+  hooksCount: number;
 }
 
 function getMcpServerNames(filePath: string): Set<string> {
-	if (!fs.existsSync(filePath)) return new Set();
-	try {
-		const content = fs.readFileSync(filePath, "utf8");
-		const config = JSON.parse(content);
-		if (config.mcpServers && typeof config.mcpServers === "object") {
-			return new Set(Object.keys(config.mcpServers));
-		}
-	} catch {
-		// Ignore errors
-	}
-	return new Set();
+  if (!fs.existsSync(filePath)) return new Set();
+  try {
+    const content = fs.readFileSync(filePath, "utf8");
+    const config = JSON.parse(content);
+    if (config.mcpServers && typeof config.mcpServers === "object") {
+      return new Set(Object.keys(config.mcpServers));
+    }
+  } catch {
+    // Ignore errors
+  }
+  return new Set();
 }
 
 function countMcpServersInFile(filePath: string, excludeFrom?: string): number {
-	const servers = getMcpServerNames(filePath);
-	if (excludeFrom) {
-		const exclude = getMcpServerNames(excludeFrom);
-		for (const name of exclude) {
-			servers.delete(name);
-		}
-	}
-	return servers.size;
+  const servers = getMcpServerNames(filePath);
+  if (excludeFrom) {
+    const exclude = getMcpServerNames(excludeFrom);
+    for (const name of exclude) {
+      servers.delete(name);
+    }
+  }
+  return servers.size;
 }
 
 function countHooksInFile(filePath: string): number {
-	if (!fs.existsSync(filePath)) return 0;
-	try {
-		const content = fs.readFileSync(filePath, "utf8");
-		const config = JSON.parse(content);
-		if (config.hooks && typeof config.hooks === "object") {
-			return Object.keys(config.hooks).length;
-		}
-	} catch {
-		// Ignore errors
-	}
-	return 0;
+  if (!fs.existsSync(filePath)) return 0;
+  try {
+    const content = fs.readFileSync(filePath, "utf8");
+    const config = JSON.parse(content);
+    if (config.hooks && typeof config.hooks === "object") {
+      return Object.keys(config.hooks).length;
+    }
+  } catch {
+    // Ignore errors
+  }
+  return 0;
 }
 
 function countRulesInDir(rulesDir: string): number {
-	if (!fs.existsSync(rulesDir)) return 0;
-	let count = 0;
-	try {
-		const entries = fs.readdirSync(rulesDir, { withFileTypes: true });
-		for (const entry of entries) {
-			const fullPath = path.join(rulesDir, entry.name);
-			if (entry.isDirectory()) {
-				count += countRulesInDir(fullPath);
-			} else if (entry.isFile() && entry.name.endsWith(".md")) {
-				count++;
-			}
-		}
-	} catch {
-		// Ignore errors
-	}
-	return count;
+  if (!fs.existsSync(rulesDir)) return 0;
+  let count = 0;
+  try {
+    const entries = fs.readdirSync(rulesDir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(rulesDir, entry.name);
+      if (entry.isDirectory()) {
+        count += countRulesInDir(fullPath);
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        count++;
+      }
+    }
+  } catch {
+    // Ignore errors
+  }
+  return count;
 }
 
 export async function countConfigs(cwd?: string): Promise<ConfigCounts> {
-	let claudeMdCount = 0;
-	let rulesCount = 0;
-	let mcpCount = 0;
-	let hooksCount = 0;
+  let claudeMdCount = 0;
+  let rulesCount = 0;
+  let mcpCount = 0;
+  let hooksCount = 0;
 
-	const homeDir = os.homedir();
-	const claudeDir = path.join(homeDir, ".claude");
+  const homeDir = os.homedir();
+  const claudeDir = path.join(homeDir, ".claude");
 
-	// === USER SCOPE ===
+  // === USER SCOPE ===
 
-	// ~/.claude/CLAUDE.md
-	if (fs.existsSync(path.join(claudeDir, "CLAUDE.md"))) {
-		claudeMdCount++;
-	}
+  // ~/.claude/CLAUDE.md
+  if (fs.existsSync(path.join(claudeDir, "CLAUDE.md"))) {
+    claudeMdCount++;
+  }
 
-	// ~/.claude/rules/*.md
-	rulesCount += countRulesInDir(path.join(claudeDir, "rules"));
+  // ~/.claude/rules/*.md
+  rulesCount += countRulesInDir(path.join(claudeDir, "rules"));
 
-	// ~/.claude/settings.json (MCPs and hooks)
-	const userSettings = path.join(claudeDir, "settings.json");
-	mcpCount += countMcpServersInFile(userSettings);
-	hooksCount += countHooksInFile(userSettings);
+  // ~/.claude/settings.json (MCPs and hooks)
+  const userSettings = path.join(claudeDir, "settings.json");
+  mcpCount += countMcpServersInFile(userSettings);
+  hooksCount += countHooksInFile(userSettings);
 
-	// ~/.claude.json (additional user-scope MCPs, dedupe by counting unique)
-	const userClaudeJson = path.join(homeDir, ".claude.json");
-	mcpCount += countMcpServersInFile(userClaudeJson, userSettings);
+  // ~/.claude.json (additional user-scope MCPs, dedupe by counting unique)
+  const userClaudeJson = path.join(homeDir, ".claude.json");
+  mcpCount += countMcpServersInFile(userClaudeJson, userSettings);
 
-	// === PROJECT SCOPE ===
+  // === PROJECT SCOPE ===
 
-	if (cwd) {
-		// {cwd}/CLAUDE.md
-		if (fs.existsSync(path.join(cwd, "CLAUDE.md"))) {
-			claudeMdCount++;
-		}
+  if (cwd) {
+    // {cwd}/CLAUDE.md
+    if (fs.existsSync(path.join(cwd, "CLAUDE.md"))) {
+      claudeMdCount++;
+    }
 
-		// {cwd}/CLAUDE.local.md
-		if (fs.existsSync(path.join(cwd, "CLAUDE.local.md"))) {
-			claudeMdCount++;
-		}
+    // {cwd}/CLAUDE.local.md
+    if (fs.existsSync(path.join(cwd, "CLAUDE.local.md"))) {
+      claudeMdCount++;
+    }
 
-		// {cwd}/.claude/CLAUDE.md (alternative location)
-		if (fs.existsSync(path.join(cwd, ".claude", "CLAUDE.md"))) {
-			claudeMdCount++;
-		}
+    // {cwd}/.claude/CLAUDE.md (alternative location)
+    if (fs.existsSync(path.join(cwd, ".claude", "CLAUDE.md"))) {
+      claudeMdCount++;
+    }
 
-		// {cwd}/.claude/CLAUDE.local.md
-		if (fs.existsSync(path.join(cwd, ".claude", "CLAUDE.local.md"))) {
-			claudeMdCount++;
-		}
+    // {cwd}/.claude/CLAUDE.local.md
+    if (fs.existsSync(path.join(cwd, ".claude", "CLAUDE.local.md"))) {
+      claudeMdCount++;
+    }
 
-		// {cwd}/.claude/rules/*.md (recursive)
-		rulesCount += countRulesInDir(path.join(cwd, ".claude", "rules"));
+    // {cwd}/.claude/rules/*.md (recursive)
+    rulesCount += countRulesInDir(path.join(cwd, ".claude", "rules"));
 
-		// {cwd}/.mcp.json (project MCP config)
-		mcpCount += countMcpServersInFile(path.join(cwd, ".mcp.json"));
+    // {cwd}/.mcp.json (project MCP config)
+    mcpCount += countMcpServersInFile(path.join(cwd, ".mcp.json"));
 
-		// {cwd}/.claude/settings.json (project settings)
-		const projectSettings = path.join(cwd, ".claude", "settings.json");
-		mcpCount += countMcpServersInFile(projectSettings);
-		hooksCount += countHooksInFile(projectSettings);
+    // {cwd}/.claude/settings.json (project settings)
+    const projectSettings = path.join(cwd, ".claude", "settings.json");
+    mcpCount += countMcpServersInFile(projectSettings);
+    hooksCount += countHooksInFile(projectSettings);
 
-		// {cwd}/.claude/settings.local.json (local project settings)
-		const localSettings = path.join(cwd, ".claude", "settings.local.json");
-		mcpCount += countMcpServersInFile(localSettings);
-		hooksCount += countHooksInFile(localSettings);
-	}
+    // {cwd}/.claude/settings.local.json (local project settings)
+    const localSettings = path.join(cwd, ".claude", "settings.local.json");
+    mcpCount += countMcpServersInFile(localSettings);
+    hooksCount += countHooksInFile(localSettings);
+  }
 
-	return { claudeMdCount, rulesCount, mcpCount, hooksCount };
+  return { claudeMdCount, rulesCount, mcpCount, hooksCount };
 }

--- a/statusline/src/git.ts
+++ b/statusline/src/git.ts
@@ -4,16 +4,16 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 export async function getGitBranch(cwd?: string): Promise<string | null> {
-	if (!cwd) return null;
+  if (!cwd) return null;
 
-	try {
-		const { stdout } = await execFileAsync(
-			"git",
-			["rev-parse", "--abbrev-ref", "HEAD"],
-			{ cwd, timeout: 1000, encoding: "utf8" },
-		);
-		return stdout.trim() || null;
-	} catch {
-		return null;
-	}
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["rev-parse", "--abbrev-ref", "HEAD"],
+      { cwd, timeout: 1000, encoding: "utf8" },
+    );
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
 }

--- a/statusline/src/index.ts
+++ b/statusline/src/index.ts
@@ -7,87 +7,87 @@ import { parseTranscript } from "./transcript.js";
 import type { RenderContext } from "./types.js";
 
 export type MainDeps = {
-	readStdin: typeof readStdin;
-	parseTranscript: typeof parseTranscript;
-	countConfigs: typeof countConfigs;
-	getGitBranch: typeof getGitBranch;
-	render: typeof render;
-	now: () => number;
-	log: (...args: unknown[]) => void;
+  readStdin: typeof readStdin;
+  parseTranscript: typeof parseTranscript;
+  countConfigs: typeof countConfigs;
+  getGitBranch: typeof getGitBranch;
+  render: typeof render;
+  now: () => number;
+  log: (...args: unknown[]) => void;
 };
 
 export async function main(overrides: Partial<MainDeps> = {}): Promise<void> {
-	const deps: MainDeps = {
-		readStdin,
-		parseTranscript,
-		countConfigs,
-		getGitBranch,
-		render,
-		now: () => Date.now(),
-		log: console.log,
-		...overrides,
-	};
+  const deps: MainDeps = {
+    readStdin,
+    parseTranscript,
+    countConfigs,
+    getGitBranch,
+    render,
+    now: () => Date.now(),
+    log: console.log,
+    ...overrides,
+  };
 
-	try {
-		const stdin = await deps.readStdin();
+  try {
+    const stdin = await deps.readStdin();
 
-		if (!stdin) {
-			deps.log("[claude-hud] Initializing...");
-			return;
-		}
+    if (!stdin) {
+      deps.log("[claude-hud] Initializing...");
+      return;
+    }
 
-		const transcriptPath = stdin.transcript_path ?? "";
-		const transcript = await deps.parseTranscript(transcriptPath);
+    const transcriptPath = stdin.transcript_path ?? "";
+    const transcript = await deps.parseTranscript(transcriptPath);
 
-		const { claudeMdCount, rulesCount, mcpCount, hooksCount } =
-			await deps.countConfigs(stdin.cwd);
+    const { claudeMdCount, rulesCount, mcpCount, hooksCount } =
+      await deps.countConfigs(stdin.cwd);
 
-		const gitBranch = await deps.getGitBranch(stdin.cwd);
+    const gitBranch = await deps.getGitBranch(stdin.cwd);
 
-		const sessionDuration = formatSessionDuration(
-			transcript.sessionStart,
-			deps.now,
-		);
+    const sessionDuration = formatSessionDuration(
+      transcript.sessionStart,
+      deps.now,
+    );
 
-		const ctx: RenderContext = {
-			stdin,
-			transcript,
-			claudeMdCount,
-			rulesCount,
-			mcpCount,
-			hooksCount,
-			sessionDuration,
-			gitBranch,
-		};
+    const ctx: RenderContext = {
+      stdin,
+      transcript,
+      claudeMdCount,
+      rulesCount,
+      mcpCount,
+      hooksCount,
+      sessionDuration,
+      gitBranch,
+    };
 
-		deps.render(ctx);
-	} catch (error) {
-		deps.log(
-			"[claude-hud] Error:",
-			error instanceof Error ? error.message : "Unknown error",
-		);
-	}
+    deps.render(ctx);
+  } catch (error) {
+    deps.log(
+      "[claude-hud] Error:",
+      error instanceof Error ? error.message : "Unknown error",
+    );
+  }
 }
 
 export function formatSessionDuration(
-	sessionStart?: Date,
-	now: () => number = () => Date.now(),
+  sessionStart?: Date,
+  now: () => number = () => Date.now(),
 ): string {
-	if (!sessionStart) {
-		return "";
-	}
+  if (!sessionStart) {
+    return "";
+  }
 
-	const ms = now() - sessionStart.getTime();
-	const mins = Math.floor(ms / 60000);
+  const ms = now() - sessionStart.getTime();
+  const mins = Math.floor(ms / 60000);
 
-	if (mins < 1) return "<1m";
-	if (mins < 60) return `${mins}m`;
+  if (mins < 1) return "<1m";
+  if (mins < 60) return `${mins}m`;
 
-	const hours = Math.floor(mins / 60);
-	const remainingMins = mins % 60;
-	return `${hours}h ${remainingMins}m`;
+  const hours = Math.floor(mins / 60);
+  const remainingMins = mins % 60;
+  return `${hours}h ${remainingMins}m`;
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-	void main();
+  void main();
 }

--- a/statusline/src/render/agents-line.ts
+++ b/statusline/src/render/agents-line.ts
@@ -2,55 +2,55 @@ import type { AgentEntry, RenderContext } from "../types.js";
 import { dim, green, magenta, yellow } from "./colors.js";
 
 export function renderAgentsLine(ctx: RenderContext): string | null {
-	const { agents } = ctx.transcript;
+  const { agents } = ctx.transcript;
 
-	const runningAgents = agents.filter((a) => a.status === "running");
-	const recentCompleted = agents
-		.filter((a) => a.status === "completed")
-		.slice(-2);
+  const runningAgents = agents.filter((a) => a.status === "running");
+  const recentCompleted = agents
+    .filter((a) => a.status === "completed")
+    .slice(-2);
 
-	const toShow = [...runningAgents, ...recentCompleted].slice(-3);
+  const toShow = [...runningAgents, ...recentCompleted].slice(-3);
 
-	if (toShow.length === 0) {
-		return null;
-	}
+  if (toShow.length === 0) {
+    return null;
+  }
 
-	const lines: string[] = [];
+  const lines: string[] = [];
 
-	for (const agent of toShow) {
-		lines.push(formatAgent(agent));
-	}
+  for (const agent of toShow) {
+    lines.push(formatAgent(agent));
+  }
 
-	return lines.join("\n");
+  return lines.join("\n");
 }
 
 function formatAgent(agent: AgentEntry): string {
-	const statusIcon = agent.status === "running" ? yellow("◐") : green("✓");
-	const type = magenta(agent.type);
-	const model = agent.model ? dim(`[${agent.model}]`) : "";
-	const desc = agent.description
-		? dim(`: ${truncateDesc(agent.description)}`)
-		: "";
-	const elapsed = formatElapsed(agent);
+  const statusIcon = agent.status === "running" ? yellow("◐") : green("✓");
+  const type = magenta(agent.type);
+  const model = agent.model ? dim(`[${agent.model}]`) : "";
+  const desc = agent.description
+    ? dim(`: ${truncateDesc(agent.description)}`)
+    : "";
+  const elapsed = formatElapsed(agent);
 
-	return `${statusIcon} ${type}${model ? ` ${model}` : ""}${desc} ${dim(`(${elapsed})`)}`;
+  return `${statusIcon} ${type}${model ? ` ${model}` : ""}${desc} ${dim(`(${elapsed})`)}`;
 }
 
 function truncateDesc(desc: string, maxLen: number = 40): string {
-	if (desc.length <= maxLen) return desc;
-	return `${desc.slice(0, maxLen - 3)}...`;
+  if (desc.length <= maxLen) return desc;
+  return `${desc.slice(0, maxLen - 3)}...`;
 }
 
 function formatElapsed(agent: AgentEntry): string {
-	const now = Date.now();
-	const start = agent.startTime.getTime();
-	const end = agent.endTime?.getTime() ?? now;
-	const ms = end - start;
+  const now = Date.now();
+  const start = agent.startTime.getTime();
+  const end = agent.endTime?.getTime() ?? now;
+  const ms = end - start;
 
-	if (ms < 1000) return "<1s";
-	if (ms < 60000) return `${Math.round(ms / 1000)}s`;
+  if (ms < 1000) return "<1s";
+  if (ms < 60000) return `${Math.round(ms / 1000)}s`;
 
-	const mins = Math.floor(ms / 60000);
-	const secs = Math.round((ms % 60000) / 1000);
-	return `${mins}m ${secs}s`;
+  const mins = Math.floor(ms / 60000);
+  const secs = Math.round((ms % 60000) / 1000);
+  return `${mins}m ${secs}s`;
 }

--- a/statusline/src/render/colors.ts
+++ b/statusline/src/render/colors.ts
@@ -8,38 +8,38 @@ const MAGENTA = "\x1b[35m";
 const CYAN = "\x1b[36m";
 
 export function green(text: string): string {
-	return `${GREEN}${text}${RESET}`;
+  return `${GREEN}${text}${RESET}`;
 }
 
 export function yellow(text: string): string {
-	return `${YELLOW}${text}${RESET}`;
+  return `${YELLOW}${text}${RESET}`;
 }
 
 export function red(text: string): string {
-	return `${RED}${text}${RESET}`;
+  return `${RED}${text}${RESET}`;
 }
 
 export function cyan(text: string): string {
-	return `${CYAN}${text}${RESET}`;
+  return `${CYAN}${text}${RESET}`;
 }
 
 export function magenta(text: string): string {
-	return `${MAGENTA}${text}${RESET}`;
+  return `${MAGENTA}${text}${RESET}`;
 }
 
 export function dim(text: string): string {
-	return `${DIM}${text}${RESET}`;
+  return `${DIM}${text}${RESET}`;
 }
 
 export function getContextColor(percent: number): string {
-	if (percent >= 85) return RED;
-	if (percent >= 70) return YELLOW;
-	return GREEN;
+  if (percent >= 85) return RED;
+  if (percent >= 70) return YELLOW;
+  return GREEN;
 }
 
 export function coloredBar(percent: number, width: number = 10): string {
-	const filled = Math.round((percent / 100) * width);
-	const empty = width - filled;
-	const color = getContextColor(percent);
-	return `${color}${"█".repeat(filled)}${DIM}${"░".repeat(empty)}${RESET}`;
+  const filled = Math.round((percent / 100) * width);
+  const empty = width - filled;
+  const color = getContextColor(percent);
+  return `${color}${"█".repeat(filled)}${DIM}${"░".repeat(empty)}${RESET}`;
 }

--- a/statusline/src/render/index.ts
+++ b/statusline/src/render/index.ts
@@ -6,30 +6,30 @@ import { renderTodosLine } from "./todos-line.js";
 import { renderToolsLine } from "./tools-line.js";
 
 export function render(ctx: RenderContext): void {
-	const lines: string[] = [];
+  const lines: string[] = [];
 
-	const sessionLine = renderSessionLine(ctx);
-	if (sessionLine) {
-		lines.push(sessionLine);
-	}
+  const sessionLine = renderSessionLine(ctx);
+  if (sessionLine) {
+    lines.push(sessionLine);
+  }
 
-	const toolsLine = renderToolsLine(ctx);
-	if (toolsLine) {
-		lines.push(toolsLine);
-	}
+  const toolsLine = renderToolsLine(ctx);
+  if (toolsLine) {
+    lines.push(toolsLine);
+  }
 
-	const agentsLine = renderAgentsLine(ctx);
-	if (agentsLine) {
-		lines.push(agentsLine);
-	}
+  const agentsLine = renderAgentsLine(ctx);
+  if (agentsLine) {
+    lines.push(agentsLine);
+  }
 
-	const todosLine = renderTodosLine(ctx);
-	if (todosLine) {
-		lines.push(todosLine);
-	}
+  const todosLine = renderTodosLine(ctx);
+  if (todosLine) {
+    lines.push(todosLine);
+  }
 
-	for (const line of lines) {
-		const outputLine = `${RESET}${line.replace(/ /g, "\u00A0")}`;
-		console.log(outputLine);
-	}
+  for (const line of lines) {
+    const outputLine = `${RESET}${line.replace(/ /g, "\u00A0")}`;
+    console.log(outputLine);
+  }
 }

--- a/statusline/src/render/session-line.ts
+++ b/statusline/src/render/session-line.ts
@@ -2,77 +2,77 @@ import path from "node:path";
 import { getContextPercent, getModelName } from "../stdin.js";
 import type { RenderContext } from "../types.js";
 import {
-	coloredBar,
-	cyan,
-	dim,
-	getContextColor,
-	magenta,
-	RESET,
-	yellow,
+  coloredBar,
+  cyan,
+  dim,
+  getContextColor,
+  magenta,
+  RESET,
+  yellow,
 } from "./colors.js";
 
 export function renderSessionLine(ctx: RenderContext): string {
-	const model = getModelName(ctx.stdin);
-	const percent = getContextPercent(ctx.stdin);
-	const bar = coloredBar(percent);
+  const model = getModelName(ctx.stdin);
+  const percent = getContextPercent(ctx.stdin);
+  const bar = coloredBar(percent);
 
-	const parts: string[] = [];
+  const parts: string[] = [];
 
-	parts.push(
-		`${cyan(`[${model}]`)} ${bar} ${getContextColor(percent)}${percent}%${RESET}`,
-	);
+  parts.push(
+    `${cyan(`[${model}]`)} ${bar} ${getContextColor(percent)}${percent}%${RESET}`,
+  );
 
-	if (ctx.stdin.cwd) {
-		const projectName = path.basename(ctx.stdin.cwd) || ctx.stdin.cwd;
-		const branchPart = ctx.gitBranch
-			? ` ${magenta("git:(")}${cyan(ctx.gitBranch)}${magenta(")")}`
-			: "";
-		parts.push(`${yellow(projectName)}${branchPart}`);
-	}
+  if (ctx.stdin.cwd) {
+    const projectName = path.basename(ctx.stdin.cwd) || ctx.stdin.cwd;
+    const branchPart = ctx.gitBranch
+      ? ` ${magenta("git:(")}${cyan(ctx.gitBranch)}${magenta(")")}`
+      : "";
+    parts.push(`${yellow(projectName)}${branchPart}`);
+  }
 
-	if (ctx.claudeMdCount > 0) {
-		parts.push(dim(`${ctx.claudeMdCount} CLAUDE.md`));
-	}
+  if (ctx.claudeMdCount > 0) {
+    parts.push(dim(`${ctx.claudeMdCount} CLAUDE.md`));
+  }
 
-	if (ctx.rulesCount > 0) {
-		parts.push(dim(`${ctx.rulesCount} rules`));
-	}
+  if (ctx.rulesCount > 0) {
+    parts.push(dim(`${ctx.rulesCount} rules`));
+  }
 
-	if (ctx.mcpCount > 0) {
-		parts.push(dim(`${ctx.mcpCount} MCPs`));
-	}
+  if (ctx.mcpCount > 0) {
+    parts.push(dim(`${ctx.mcpCount} MCPs`));
+  }
 
-	if (ctx.hooksCount > 0) {
-		parts.push(dim(`${ctx.hooksCount} hooks`));
-	}
+  if (ctx.hooksCount > 0) {
+    parts.push(dim(`${ctx.hooksCount} hooks`));
+  }
 
-	if (ctx.sessionDuration) {
-		parts.push(dim(`⏱️  ${ctx.sessionDuration}`));
-	}
+  if (ctx.sessionDuration) {
+    parts.push(dim(`⏱️  ${ctx.sessionDuration}`));
+  }
 
-	let line = parts.join(" | ");
+  let line = parts.join(" | ");
 
-	if (percent >= 85) {
-		const usage = ctx.stdin.context_window?.current_usage;
-		if (usage) {
-			const input = formatTokens(usage.input_tokens ?? 0);
-			const cache = formatTokens(
-				(usage.cache_creation_input_tokens ?? 0) +
-					(usage.cache_read_input_tokens ?? 0),
-			);
-			line += dim(` (in: ${input}, cache: ${cache})`);
-		}
-	}
+  if (percent >= 85) {
+    const usage = ctx.stdin.context_window?.current_usage;
+    if (usage) {
+      const input = formatTokens(usage.input_tokens ?? 0);
+      const cache = formatTokens(
+        (usage.cache_creation_input_tokens ?? 0) +
+          (usage.cache_read_input_tokens ?? 0),
+      );
+      line += dim(` (in: ${input}, cache: ${cache})`);
+    }
+  }
 
-	return line;
+  return line;
 }
 
 function formatTokens(n: number): string {
-	if (n >= 1000000) {
-		return `${(n / 1000000).toFixed(1)}M`;
-	}
-	if (n >= 1000) {
-		return `${(n / 1000).toFixed(0)}k`;
-	}
-	return n.toString();
+  if (n >= 1000000) {
+    return `${(n / 1000000).toFixed(1)}M`;
+  }
+  if (n >= 1000) {
+    return `${(n / 1000).toFixed(0)}k`;
+  }
+  return n.toString();
 }

--- a/statusline/src/render/todos-line.ts
+++ b/statusline/src/render/todos-line.ts
@@ -2,30 +2,30 @@ import type { RenderContext } from "../types.js";
 import { dim, green, yellow } from "./colors.js";
 
 export function renderTodosLine(ctx: RenderContext): string | null {
-	const { todos } = ctx.transcript;
+  const { todos } = ctx.transcript;
 
-	if (!todos || todos.length === 0) {
-		return null;
-	}
+  if (!todos || todos.length === 0) {
+    return null;
+  }
 
-	const inProgress = todos.find((t) => t.status === "in_progress");
-	const completed = todos.filter((t) => t.status === "completed").length;
-	const total = todos.length;
+  const inProgress = todos.find((t) => t.status === "in_progress");
+  const completed = todos.filter((t) => t.status === "completed").length;
+  const total = todos.length;
 
-	if (!inProgress) {
-		if (completed === total && total > 0) {
-			return `${green("✓")} All todos complete ${dim(`(${completed}/${total})`)}`;
-		}
-		return null;
-	}
+  if (!inProgress) {
+    if (completed === total && total > 0) {
+      return `${green("✓")} All todos complete ${dim(`(${completed}/${total})`)}`;
+    }
+    return null;
+  }
 
-	const content = truncateContent(inProgress.content);
-	const progress = dim(`(${completed}/${total})`);
+  const content = truncateContent(inProgress.content);
+  const progress = dim(`(${completed}/${total})`);
 
-	return `${yellow("▸")} ${content} ${progress}`;
+  return `${yellow("▸")} ${content} ${progress}`;
 }
 
 function truncateContent(content: string, maxLen: number = 50): string {
-	if (content.length <= maxLen) return content;
-	return `${content.slice(0, maxLen - 3)}...`;
+  if (content.length <= maxLen) return content;
+  return `${content.slice(0, maxLen - 3)}...`;
 }

--- a/statusline/src/render/tools-line.ts
+++ b/statusline/src/render/tools-line.ts
@@ -2,56 +2,56 @@ import type { RenderContext } from "../types.js";
 import { cyan, dim, green, yellow } from "./colors.js";
 
 export function renderToolsLine(ctx: RenderContext): string | null {
-	const { tools } = ctx.transcript;
+  const { tools } = ctx.transcript;
 
-	if (tools.length === 0) {
-		return null;
-	}
+  if (tools.length === 0) {
+    return null;
+  }
 
-	const parts: string[] = [];
+  const parts: string[] = [];
 
-	const runningTools = tools.filter((t) => t.status === "running");
-	const completedTools = tools.filter(
-		(t) => t.status === "completed" || t.status === "error",
-	);
+  const runningTools = tools.filter((t) => t.status === "running");
+  const completedTools = tools.filter(
+    (t) => t.status === "completed" || t.status === "error",
+  );
 
-	for (const tool of runningTools.slice(-2)) {
-		const target = tool.target ? truncatePath(tool.target) : "";
-		parts.push(
-			`${yellow("◐")} ${cyan(tool.name)}${target ? dim(`: ${target}`) : ""}`,
-		);
-	}
+  for (const tool of runningTools.slice(-2)) {
+    const target = tool.target ? truncatePath(tool.target) : "";
+    parts.push(
+      `${yellow("◐")} ${cyan(tool.name)}${target ? dim(`: ${target}`) : ""}`,
+    );
+  }
 
-	const toolCounts = new Map<string, number>();
-	for (const tool of completedTools) {
-		const count = toolCounts.get(tool.name) ?? 0;
-		toolCounts.set(tool.name, count + 1);
-	}
+  const toolCounts = new Map<string, number>();
+  for (const tool of completedTools) {
+    const count = toolCounts.get(tool.name) ?? 0;
+    toolCounts.set(tool.name, count + 1);
+  }
 
-	const sortedTools = Array.from(toolCounts.entries())
-		.sort((a, b) => b[1] - a[1])
-		.slice(0, 4);
+  const sortedTools = Array.from(toolCounts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 4);
 
-	for (const [name, count] of sortedTools) {
-		parts.push(`${green("✓")} ${name} ${dim(`×${count}`)}`);
-	}
+  for (const [name, count] of sortedTools) {
+    parts.push(`${green("✓")} ${name} ${dim(`×${count}`)}`);
+  }
 
-	if (parts.length === 0) {
-		return null;
-	}
+  if (parts.length === 0) {
+    return null;
+  }
 
-	return parts.join(" | ");
+  return parts.join(" | ");
 }
 
 function truncatePath(path: string, maxLen: number = 20): string {
-	if (path.length <= maxLen) return path;
+  if (path.length <= maxLen) return path;
 
-	const parts = path.split("/");
-	const filename = parts.pop() || path;
+  const parts = path.split("/");
+  const filename = parts.pop() || path;
 
-	if (filename.length >= maxLen) {
-		return `${filename.slice(0, maxLen - 3)}...`;
-	}
+  if (filename.length >= maxLen) {
+    return `${filename.slice(0, maxLen - 3)}...`;
+  }
 
-	return `.../${filename}`;
+  return `.../${filename}`;
 }

--- a/statusline/src/stdin.ts
+++ b/statusline/src/stdin.ts
@@ -2,47 +2,47 @@ import { AUTOCOMPACT_BUFFER } from "./constants.js";
 import type { StdinData } from "./types.js";
 
 export async function readStdin(): Promise<StdinData | null> {
-	if (process.stdin.isTTY) {
-		return null;
-	}
+  if (process.stdin.isTTY) {
+    return null;
+  }
 
-	const chunks: string[] = [];
+  const chunks: string[] = [];
 
-	try {
-		process.stdin.setEncoding("utf8");
-		for await (const chunk of process.stdin) {
-			chunks.push(chunk as string);
-		}
-		const raw = chunks.join("");
-		if (!raw.trim()) {
-			return null;
-		}
-		return JSON.parse(raw) as StdinData;
-	} catch {
-		return null;
-	}
+  try {
+    process.stdin.setEncoding("utf8");
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk as string);
+    }
+    const raw = chunks.join("");
+    if (!raw.trim()) {
+      return null;
+    }
+    return JSON.parse(raw) as StdinData;
+  } catch {
+    return null;
+  }
 }
 
 export function getContextPercent(stdin: StdinData): number {
-	const usage = stdin.context_window?.current_usage;
-	const size = stdin.context_window?.context_window_size;
+  const usage = stdin.context_window?.current_usage;
+  const size = stdin.context_window?.context_window_size;
 
-	// Guard against missing data or invalid context window size
-	if (!usage || !size || size <= AUTOCOMPACT_BUFFER) {
-		return 0;
-	}
+  // Guard against missing data or invalid context window size
+  if (!usage || !size || size <= AUTOCOMPACT_BUFFER) {
+    return 0;
+  }
 
-	const totalTokens =
-		(usage.input_tokens ?? 0) +
-		(usage.cache_creation_input_tokens ?? 0) +
-		(usage.cache_read_input_tokens ?? 0);
+  const totalTokens =
+    (usage.input_tokens ?? 0) +
+    (usage.cache_creation_input_tokens ?? 0) +
+    (usage.cache_read_input_tokens ?? 0);
 
-	return Math.min(
-		100,
-		Math.round(((totalTokens + AUTOCOMPACT_BUFFER) / size) * 100),
-	);
+  return Math.min(
+    100,
+    Math.round(((totalTokens + AUTOCOMPACT_BUFFER) / size) * 100),
+  );
 }
 
 export function getModelName(stdin: StdinData): string {
-	return stdin.model?.display_name ?? stdin.model?.id ?? "Unknown";
+  return stdin.model?.display_name ?? stdin.model?.id ?? "Unknown";
 }

--- a/statusline/src/transcript.ts
+++ b/statusline/src/transcript.ts
@@ -1,156 +1,156 @@
 import * as fs from "node:fs";
 import * as readline from "node:readline";
 import type {
-	AgentEntry,
-	TodoItem,
-	ToolEntry,
-	TranscriptData,
+  AgentEntry,
+  TodoItem,
+  ToolEntry,
+  TranscriptData,
 } from "./types.js";
 
 interface TranscriptLine {
-	timestamp?: string;
-	message?: {
-		content?: ContentBlock[];
-	};
+  timestamp?: string;
+  message?: {
+    content?: ContentBlock[];
+  };
 }
 
 interface ContentBlock {
-	type: string;
-	id?: string;
-	name?: string;
-	input?: Record<string, unknown>;
-	tool_use_id?: string;
-	is_error?: boolean;
+  type: string;
+  id?: string;
+  name?: string;
+  input?: Record<string, unknown>;
+  tool_use_id?: string;
+  is_error?: boolean;
 }
 
 export async function parseTranscript(
-	transcriptPath: string,
+  transcriptPath: string,
 ): Promise<TranscriptData> {
-	const result: TranscriptData = {
-		tools: [],
-		agents: [],
-		todos: [],
-	};
+  const result: TranscriptData = {
+    tools: [],
+    agents: [],
+    todos: [],
+  };
 
-	if (!transcriptPath || !fs.existsSync(transcriptPath)) {
-		return result;
-	}
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+    return result;
+  }
 
-	const toolMap = new Map<string, ToolEntry>();
-	const agentMap = new Map<string, AgentEntry>();
-	const latestTodos: TodoItem[] = [];
+  const toolMap = new Map<string, ToolEntry>();
+  const agentMap = new Map<string, AgentEntry>();
+  const latestTodos: TodoItem[] = [];
 
-	try {
-		const fileStream = fs.createReadStream(transcriptPath);
-		const rl = readline.createInterface({
-			input: fileStream,
-			crlfDelay: Infinity,
-		});
+  try {
+    const fileStream = fs.createReadStream(transcriptPath);
+    const rl = readline.createInterface({
+      input: fileStream,
+      crlfDelay: Infinity,
+    });
 
-		for await (const line of rl) {
-			if (!line.trim()) continue;
+    for await (const line of rl) {
+      if (!line.trim()) continue;
 
-			try {
-				const entry = JSON.parse(line) as TranscriptLine;
-				processEntry(entry, toolMap, agentMap, latestTodos, result);
-			} catch {
-				// Skip malformed lines
-			}
-		}
-	} catch {
-		// Return partial results on error
-	}
+      try {
+        const entry = JSON.parse(line) as TranscriptLine;
+        processEntry(entry, toolMap, agentMap, latestTodos, result);
+      } catch {
+        // Skip malformed lines
+      }
+    }
+  } catch {
+    // Return partial results on error
+  }
 
-	result.tools = Array.from(toolMap.values()).slice(-20);
-	result.agents = Array.from(agentMap.values()).slice(-10);
-	result.todos = latestTodos;
+  result.tools = Array.from(toolMap.values()).slice(-20);
+  result.agents = Array.from(agentMap.values()).slice(-10);
+  result.todos = latestTodos;
 
-	return result;
+  return result;
 }
 
 function processEntry(
-	entry: TranscriptLine,
-	toolMap: Map<string, ToolEntry>,
-	agentMap: Map<string, AgentEntry>,
-	latestTodos: TodoItem[],
-	result: TranscriptData,
+  entry: TranscriptLine,
+  toolMap: Map<string, ToolEntry>,
+  agentMap: Map<string, AgentEntry>,
+  latestTodos: TodoItem[],
+  result: TranscriptData,
 ): void {
-	const timestamp = entry.timestamp ? new Date(entry.timestamp) : new Date();
+  const timestamp = entry.timestamp ? new Date(entry.timestamp) : new Date();
 
-	if (!result.sessionStart && entry.timestamp) {
-		result.sessionStart = timestamp;
-	}
+  if (!result.sessionStart && entry.timestamp) {
+    result.sessionStart = timestamp;
+  }
 
-	const content = entry.message?.content;
-	if (!content || !Array.isArray(content)) return;
+  const content = entry.message?.content;
+  if (!content || !Array.isArray(content)) return;
 
-	for (const block of content) {
-		if (block.type === "tool_use" && block.id && block.name) {
-			const toolEntry: ToolEntry = {
-				id: block.id,
-				name: block.name,
-				target: extractTarget(block.name, block.input),
-				status: "running",
-				startTime: timestamp,
-			};
+  for (const block of content) {
+    if (block.type === "tool_use" && block.id && block.name) {
+      const toolEntry: ToolEntry = {
+        id: block.id,
+        name: block.name,
+        target: extractTarget(block.name, block.input),
+        status: "running",
+        startTime: timestamp,
+      };
 
-			if (block.name === "Task") {
-				const input = block.input as Record<string, unknown>;
-				const agentEntry: AgentEntry = {
-					id: block.id,
-					type: (input?.subagent_type as string) ?? "unknown",
-					model: (input?.model as string) ?? undefined,
-					description: (input?.description as string) ?? undefined,
-					status: "running",
-					startTime: timestamp,
-				};
-				agentMap.set(block.id, agentEntry);
-			} else if (block.name === "TodoWrite") {
-				const input = block.input as { todos?: TodoItem[] };
-				if (input?.todos && Array.isArray(input.todos)) {
-					latestTodos.length = 0;
-					latestTodos.push(...input.todos);
-				}
-			} else {
-				toolMap.set(block.id, toolEntry);
-			}
-		}
+      if (block.name === "Task") {
+        const input = block.input as Record<string, unknown>;
+        const agentEntry: AgentEntry = {
+          id: block.id,
+          type: (input?.subagent_type as string) ?? "unknown",
+          model: (input?.model as string) ?? undefined,
+          description: (input?.description as string) ?? undefined,
+          status: "running",
+          startTime: timestamp,
+        };
+        agentMap.set(block.id, agentEntry);
+      } else if (block.name === "TodoWrite") {
+        const input = block.input as { todos?: TodoItem[] };
+        if (input?.todos && Array.isArray(input.todos)) {
+          latestTodos.length = 0;
+          latestTodos.push(...input.todos);
+        }
+      } else {
+        toolMap.set(block.id, toolEntry);
+      }
+    }
 
-		if (block.type === "tool_result" && block.tool_use_id) {
-			const tool = toolMap.get(block.tool_use_id);
-			if (tool) {
-				tool.status = block.is_error ? "error" : "completed";
-				tool.endTime = timestamp;
-			}
+    if (block.type === "tool_result" && block.tool_use_id) {
+      const tool = toolMap.get(block.tool_use_id);
+      if (tool) {
+        tool.status = block.is_error ? "error" : "completed";
+        tool.endTime = timestamp;
+      }
 
-			const agent = agentMap.get(block.tool_use_id);
-			if (agent) {
-				agent.status = "completed";
-				agent.endTime = timestamp;
-			}
-		}
-	}
+      const agent = agentMap.get(block.tool_use_id);
+      if (agent) {
+        agent.status = "completed";
+        agent.endTime = timestamp;
+      }
+    }
+  }
 }
 
 function extractTarget(
-	toolName: string,
-	input?: Record<string, unknown>,
+  toolName: string,
+  input?: Record<string, unknown>,
 ): string | undefined {
-	if (!input) return undefined;
+  if (!input) return undefined;
 
-	switch (toolName) {
-		case "Read":
-		case "Write":
-		case "Edit":
-			return (input.file_path as string) ?? (input.path as string);
-		case "Glob":
-			return input.pattern as string;
-		case "Grep":
-			return input.pattern as string;
-		case "Bash": {
-			const cmd = input.command as string;
-			return cmd?.slice(0, 30) + (cmd?.length > 30 ? "..." : "");
-		}
-	}
-	return undefined;
+  switch (toolName) {
+    case "Read":
+    case "Write":
+    case "Edit":
+      return (input.file_path as string) ?? (input.path as string);
+    case "Glob":
+      return input.pattern as string;
+    case "Grep":
+      return input.pattern as string;
+    case "Bash": {
+      const cmd = input.command as string;
+      return cmd?.slice(0, 30) + (cmd?.length > 30 ? "..." : "");
+    }
+  }
+  return undefined;
 }

--- a/statusline/src/types.ts
+++ b/statusline/src/types.ts
@@ -1,58 +1,58 @@
 export interface StdinData {
-	transcript_path?: string;
-	cwd?: string;
-	model?: {
-		id?: string;
-		display_name?: string;
-	};
-	context_window?: {
-		context_window_size?: number;
-		current_usage?: {
-			input_tokens?: number;
-			cache_creation_input_tokens?: number;
-			cache_read_input_tokens?: number;
-		};
-	};
+  transcript_path?: string;
+  cwd?: string;
+  model?: {
+    id?: string;
+    display_name?: string;
+  };
+  context_window?: {
+    context_window_size?: number;
+    current_usage?: {
+      input_tokens?: number;
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
+    };
+  };
 }
 
 export interface ToolEntry {
-	id: string;
-	name: string;
-	target?: string;
-	status: "running" | "completed" | "error";
-	startTime: Date;
-	endTime?: Date;
+  id: string;
+  name: string;
+  target?: string;
+  status: "running" | "completed" | "error";
+  startTime: Date;
+  endTime?: Date;
 }
 
 export interface AgentEntry {
-	id: string;
-	type: string;
-	model?: string;
-	description?: string;
-	status: "running" | "completed";
-	startTime: Date;
-	endTime?: Date;
+  id: string;
+  type: string;
+  model?: string;
+  description?: string;
+  status: "running" | "completed";
+  startTime: Date;
+  endTime?: Date;
 }
 
 export interface TodoItem {
-	content: string;
-	status: "pending" | "in_progress" | "completed";
+  content: string;
+  status: "pending" | "in_progress" | "completed";
 }
 
 export interface TranscriptData {
-	tools: ToolEntry[];
-	agents: AgentEntry[];
-	todos: TodoItem[];
-	sessionStart?: Date;
+  tools: ToolEntry[];
+  agents: AgentEntry[];
+  todos: TodoItem[];
+  sessionStart?: Date;
 }
 
 export interface RenderContext {
-	stdin: StdinData;
-	transcript: TranscriptData;
-	claudeMdCount: number;
-	rulesCount: number;
-	mcpCount: number;
-	hooksCount: number;
-	sessionDuration: string;
-	gitBranch: string | null;
+  stdin: StdinData;
+  transcript: TranscriptData;
+  claudeMdCount: number;
+  rulesCount: number;
+  mcpCount: number;
+  hooksCount: number;
+  sessionDuration: string;
+  gitBranch: string | null;
 }

--- a/statusline/tsconfig.json
+++ b/statusline/tsconfig.json
@@ -1,8 +1,8 @@
 {
-	"compilerOptions": {
-		"module": "NodeNext",
-		"moduleResolution": "NodeNext",
-		"strict": true,
-		"skipLibCheck": true
-	}
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true
+  }
 }


### PR DESCRIPTION
## Summary

Standardizes the statusline codebase to use 2-space indentation instead of tabs for consistency with TypeScript conventions and improved readability.

## Changes

- Update `biome.json`: Change `indentStyle` from `"tab"` to `"space"`
- Add `files.includes` configuration to `biome.json`
- Reformat all TypeScript source files (15 files total)

## Impact

- **No functional changes** - This is a pure formatting change
- **Build verified** - Successfully builds after reformatting
- **Consistency** - Aligns with standard TypeScript formatting conventions

## Files Changed

```
statusline/biome.json
statusline/package.json
statusline/src/config-reader.ts
statusline/src/git.ts
statusline/src/index.ts
statusline/src/render/agents-line.ts
statusline/src/render/colors.ts
statusline/src/render/index.ts
statusline/src/render/session-line.ts
statusline/src/render/todos-line.ts
statusline/src/render/tools-line.ts
statusline/src/stdin.ts
statusline/src/transcript.ts
statusline/src/types.ts
statusline/tsconfig.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)