### PR TITLE
Improve documentation formatting and add validation insights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ skills/.marketplace/
 
 # My local Claude config for the Claude config
 .claude/
+statusline/

--- a/docs/agent-vs-skill-structure.md
+++ b/docs/agent-vs-skill-structure.md
@@ -8,7 +8,7 @@ Agents and skills both support reference materials for progressive disclosure, b
 
 **Pattern** (implemented in issue #37):
 
-```
+```text
 skills/skill-name/
 ├── SKILL.md                    ← Main skill file
 ├── reference1.md               ← Co-located at root
@@ -35,7 +35,7 @@ skills/skill-name/
 
 **Pattern** (tested 2026-01-05):
 
-```
+```text
 agents/agent-name/
 ├── agent-name.md               ← Main agent file
 └── references/                 ← Subdirectory REQUIRED
@@ -45,7 +45,7 @@ agents/agent-name/
 
 **OR simple single-file agent:**
 
-```
+```text
 agents/
 └── agent-name.md               ← Single file, no references
 ```
@@ -145,7 +145,7 @@ elif (
 
 ### Agent: claude-code-test-runner
 
-```
+```text
 agents/claude-code-test-runner/
 ├── claude-code-test-runner.md
 └── references/
@@ -155,7 +155,7 @@ agents/claude-code-test-runner/
 
 ### Skill: agent-audit
 
-```
+```text
 skills/agent-audit/
 ├── SKILL.md
 ├── approach-methodology.md

--- a/references/customization/plugin-structure-comparison.md
+++ b/references/customization/plugin-structure-comparison.md
@@ -39,7 +39,57 @@ This document compares the official Claude Code `plugin-structure` skill with ou
 - Consider creating more example files for complex workflows
 - Document word/line count targets in skill-authoring
 
-### 2. Component Organization Patterns
+### 2. Validation Constraints Drive Structure (Key Discovery)
+
+**Critical Insight** (discovered 2026-01-05):
+
+Our component structures are constrained by validation hook behavior, not just organizational preference:
+
+#### Skills: Flattened Structure
+
+```text
+skills/skill-name/
+├── SKILL.md          ← Validated for frontmatter
+├── reference1.md     ← Ignored by validation
+└── reference2.md     ← Ignored by validation
+```
+
+**Validation logic** (`hooks/validate-config.py:115-119`):
+
+```python
+if "/skills/" in file_path and "SKILL.md" in file_path:
+    file_type = "skill"
+```
+
+- Only `SKILL.md` files are validated
+- Other `.md` files in skill directory are ignored
+- **Result**: Can use flattened structure (Issue #37)
+
+#### Agents: Subdirectory Structure Required
+
+```text
+agents/agent-name/
+├── agent-name.md     ← Validated for frontmatter
+└── references/       ← Files here IGNORED by validation
+    └── file.md
+```
+
+**Validation logic** (`hooks/validate-config.py:113`):
+
+```python
+if "/agents/" in file_path and "/references/" not in file_path:
+    file_type = "agent"
+```
+
+- ALL `.md` files in agents/ are validated
+- EXCEPT files in `references/` subdirectory
+- **Result**: Must use `references/` subdirectory for resource files
+
+**Documentation**: See `docs/agent-vs-skill-structure.md` for complete rationale and testing results.
+
+**Implication**: This is a **technical constraint**, not a style choice. We cannot flatten agent structure without validation failures.
+
+### 3. Component Organization Patterns
 
 **Official Patterns We Can Apply**:
 
@@ -69,7 +119,7 @@ skills/
 │   └── command-authoring/
 └── workflows/
     ├── git-workflow/
-    
+
 ```
 
 - ⚠️ **Consider for future**: If we exceed ~20 skills
@@ -118,18 +168,44 @@ skill-name/
     └── validator.py
 ```
 
-**Our Current Implementation**:
+**Our Current Implementation** (updated 2026-01-06):
 
-- ✅ **Good**: skill-authoring uses this well
-- ⚠️ **Partial**: Most skills have references/, fewer have scripts/ or examples/
-- ❌ **Missing**: organize-folders has empty references/
+Skills now use **flattened structure** (Issue #37):
 
-**Applicable Enhancements**:
+```text
+skills/skill-name/
+├── SKILL.md              ← Main skill file
+├── reference1.md         ← Co-located at root
+├── reference2.md         ← Co-located at root
+└── examples.md           ← Co-located at root
+```
 
-1. Add examples/ directories for complex workflows
-2. Move inline examples from SKILL.md to examples/ files
-3. Create scripts/ for automation where appropriate
-4. Document the pattern in skill-authoring
+Agents use **references subdirectory** (validation constraint):
+
+```text
+agents/agent-name/
+├── agent-name.md         ← Main agent file
+└── references/           ← Required subdirectory
+    ├── file1.md
+    └── file2.md
+```
+
+**Status**:
+
+- ✅ **Implemented**: Skills use flattened structure (no subdirectories)
+- ✅ **Documented**: See `docs/agent-vs-skill-structure.md`
+- ✅ **Validated**: Validation hook enforces patterns correctly
+
+**Rationale**:
+
+- **Skills**: Validation only checks `SKILL.md`, other `.md` files ignored → can flatten
+- **Agents**: Validation checks ALL `.md` files except in `references/` → must use subdirectory
+- See `hooks/validate-config.py` for validation logic
+
+**Not Applicable**:
+
+- `examples/` subdirectories - use single `examples.md` file instead
+- `scripts/` subdirectories - not needed in current setup
 
 ### 4. Shared vs Component-Specific Resources
 
@@ -139,26 +215,40 @@ skill-name/
 - Component-specific details in each component
 - Clear delineation of scope
 
-**Our Implementation** (references/README.md):
+**Our Implementation** (updated 2026-01-06):
 
 ```text
 ~/.claude/
-├── references/          # Shared across ALL components
-│   ├── decision-matrix.md
-│   ├── when-to-use-what.md
-│   ├── naming-conventions.md
-│   ├── frontmatter-requirements.md
-│   └── hook-events.md
-└── skills/
-    └── skill-name/
-        └── references/  # Specific to this skill only
+├── references/              # Shared across ALL components
+│   ├── customization/      # Shared customization docs
+│   │   ├── decision-matrix.md
+│   │   ├── when-to-use-what.md
+│   │   ├── naming-conventions.md
+│   │   └── plugin-structure-comparison.md
+│   └── map-codebase-workflow.md
+├── skills/
+│   └── skill-name/
+│       ├── SKILL.md         # Main skill file
+│       └── reference.md     # Skill-specific reference (flattened)
+└── agents/
+    └── agent-name/
+        ├── agent-name.md    # Main agent file
+        └── references/      # Agent-specific references (subdirectory)
+            └── file.md
 ```
 
-- ✅ **Well defined**: Clear shared vs specific separation
-- ✅ **Documented**: references/README.md explains the distinction
-- ✅ **Consistent**: Skills reference shared docs using `../../references/`
+**Status**:
 
-**No changes needed**: This pattern is already well-implemented.
+- ✅ **Well defined**: Clear shared vs component-specific separation
+- ✅ **Documented**: references/README.md explains the distinction
+- ✅ **Updated**: Reflects skill flattening and agent subdirectory pattern
+- ✅ **Consistent**: Components reference shared docs using `../../references/`
+
+**Key Differences from Official**:
+
+- Skills: Flattened structure (no subdirectories)
+- Agents: Must use `references/` subdirectory (validation constraint)
+- Global references organized in `customization/` subfolder
 
 ### 5. Cross-Component Patterns
 
@@ -293,24 +383,37 @@ Not applicable to personal configuration:
 
 ## Recommendations
 
-### Immediate Actions
+### Recently Completed
 
-1. **Document categorization plan** (this file)
-   - Define groupings for when we hit 20 skills
-   - Document decision criteria
+1. ✅ **Flattened skill structure** (Issue #37)
+   - Removed `references/` subdirectories from skills
+   - Co-located all reference files at skill root
+   - Simpler structure, easier navigation
 
-2. **Address open issues** using official patterns:
-   - #66: Reduce command-audit size (progressive disclosure)
-   - #65: Populate organize-folders references or remove directory
+2. ✅ **Documented agent resource pattern** (Issue #82)
+   - Agents use `references/` subdirectory (validation constraint)
+   - See `docs/agent-vs-skill-structure.md` for rationale
 
-3. **Enhance rich resources**:
-   - Add examples/ to git-workflow
-   - Add examples/ to bash-scripting
-   - Consider scripts/lib/ for shared helpers
+3. ✅ **Organized global references**
+   - Created `references/customization/` subfolder
+   - Clear separation of concerns
+
+### Current Status
+
+**Skills** (17 total):
+
+- Using flattened structure successfully
+- Reference files co-located with SKILL.md
+- Examples integrated into skills (e.g., `examples.md`)
+
+**Agents** (2 total):
+
+- claude-code-evaluator (single file)
+- claude-code-test-runner (with references/ subdirectory)
 
 ### Future Considerations
 
-1. **At 20 skills**: Reorganize into categories
+1. **At 20 skills**: Consider categorization
 
    ```text
    skills/
@@ -331,39 +434,48 @@ Not applicable to personal configuration:
    └── README.md
    ```
 
-3. **If complexity increases**: Add more examples/
-   - Minimal examples for quick start
-   - Standard examples for common cases
-   - Advanced examples for edge cases
+3. **Agent growth**: Continue using `references/` subdirectory pattern
+   - Keep structure one level deep
+   - Link all references from main agent file
+   - Follow examples in claude-code-test-runner
 
 ## Conclusion
 
-The official plugin-structure skill provides excellent patterns that we can adapt:
+The official plugin-structure skill provides excellent patterns that we've successfully adapted:
 
-**Already Well-Aligned**:
+**Successfully Implemented**:
 
-- Progressive disclosure in many skills
-- Shared vs specific resource separation
-- Naming conventions
-- Layered architecture
+- ✅ Progressive disclosure in skills (flattened structure)
+- ✅ Agent resource pattern (references/ subdirectory)
+- ✅ Shared vs specific resource separation
+- ✅ Naming conventions and consistency
+- ✅ Layered architecture (commands → agents → skills → scripts)
 
-**Opportunities for Enhancement**:
+**Key Adaptations**:
 
-- More examples/ directories
-- Potential scripts/lib/ for shared code
-- Document future reorganization triggers
-- Address size/completeness issues in specific skills
+- **Skills**: Flattened structure (validation allows it)
+- **Agents**: Subdirectory structure (validation requires it)
+- **Global references**: Organized in customization/ subfolder
+- See `docs/agent-vs-skill-structure.md` for detailed rationale
+
+**Future Growth Paths**:
+
+- At 20 skills: Consider categorized structure
+- If script duplication: Create scripts/lib/
+- Agent growth: Follow claude-code-test-runner example
 
 **Not Applicable**:
 
 - Plugin manifest and distribution concerns
-- Plugin-specific path variables
+- Plugin-specific path variables (${CLAUDE_PLUGIN_ROOT})
 - Marketplace and versioning systems
+- Multiple subdirectory levels (keep one level deep)
 
-Our local setup already follows many best practices from the official guidance. The main value is in understanding the patterns for future growth and having clear triggers for when to reorganize.
+Our local setup has evolved beyond the initial comparison to establish patterns that work within our validation constraints while maintaining the progressive disclosure and organization benefits.
 
 ---
 
 **Created**: 2026-01-03
+**Updated**: 2026-01-06 (skill flattening, agent resources)
 **Official Source**: <https://github.com/anthropics/claude-code/tree/main/plugins/plugin-dev/skills/plugin-structure>
 **Local Context**: ~/.claude global configuration (17 skills, 13 commands, 2 agents, 6 hooks)

--- a/skills/agent-audit/resource-organization.md
+++ b/skills/agent-audit/resource-organization.md
@@ -27,7 +27,7 @@ Resource organization is how an agent structures its files to balance comprehens
 
 **Example from claude-code-test-runner**:
 
-```
+```text
 claude-code-test-runner/
 ├── claude-code-test-runner.md  # 328 lines - core workflow
 └── references/
@@ -95,7 +95,7 @@ Size isn't the only factor. Consider references when the agent has:
 
 **Structure**:
 
-```
+```text
 agents/
 └── agent-name.md  # Self-contained, typically <500 lines
 ```
@@ -130,7 +130,7 @@ allowed_tools: [Read, Glob, Grep, Bash]
 
 **Structure**:
 
-```
+```text
 agents/
 └── agent-name/
     ├── agent-name.md     # <500 lines, core workflow only
@@ -151,7 +151,7 @@ agents/
 
 **Example: claude-code-test-runner** (328 lines main + 2 references):
 
-```
+```text
 claude-code-test-runner/
 ├── claude-code-test-runner.md
 └── references/
@@ -188,7 +188,7 @@ This agent uses reference materials in the `references/` directory:
 
 **Example comparison**:
 
-```
+```markdown
 # Agent structure
 agents/my-agent/
 ├── my-agent.md
@@ -386,7 +386,7 @@ find agents/agent-name/references/ -mindepth 2 -type d
 
 **Good structure**:
 
-```
+```text
 references/
 ├── examples.md
 ├── guide.md
@@ -396,7 +396,7 @@ references/
 
 **Bad structure**:
 
-```
+```text
 references/
 ├── basics/
 │   └── intro.md
@@ -417,7 +417,7 @@ references/
 
 **Example**:
 
-```
+```text
 agents/
 └── my-agent.md  # 750 lines - too large
 ```
@@ -440,7 +440,7 @@ wc -l agents/my-agent.md
 
 Extract detailed content to references/ directory:
 
-```
+```text
 agents/
 └── my-agent/
     ├── my-agent.md         # <400 lines, core workflow
@@ -461,7 +461,7 @@ agents/
 
 **Example**:
 
-```
+```text
 agents/
 └── my-agent/
     ├── my-agent.md
@@ -488,7 +488,7 @@ ls agents/my-agent/references/*.md
 
 **Fix**:
 
-```
+```text
 agents/
 └── my-agent/
     ├── my-agent.md
@@ -515,7 +515,7 @@ Main file (my-agent.md) has no "Reference Files" section, or missing links:
 
 But `references/` has files:
 
-```
+```text
 references/
 ├── examples.md      # Not linked
 └── guide.md         # Not linked
@@ -560,7 +560,7 @@ This agent uses reference materials in the `references/` directory:
 
 **Example**:
 
-```
+```text
 references/
 ├── basics/
 │   ├── intro.md
@@ -589,7 +589,7 @@ find references/ -mindepth 2 -type d
 
 Flatten to single level, use descriptive names:
 
-```
+```text
 references/
 ├── basics-intro.md
 ├── basics-getting-started.md
@@ -599,7 +599,7 @@ references/
 
 Or consolidate related content:
 
-```
+```text
 references/
 ├── getting-started.md    # Combined basics
 ├── optimization.md       # Advanced topics
@@ -835,7 +835,7 @@ find agents/agent-name/references/ -mindepth 2 -type d
 
 **Scoring logic**:
 
-```
+```text
 Start with 10 points
 
 If main file >500 lines: -2
@@ -855,7 +855,7 @@ Final score = max(1, initial score - deductions)
 
 **Structure**:
 
-```
+```text
 claude-code-test-runner/
 ├── claude-code-test-runner.md  (328 lines)
 └── references/
@@ -892,7 +892,7 @@ This agent uses reference materials in the `references/` directory:
 
 **Structure**:
 
-```
+```text
 agents/
 └── claude-code-evaluator.md  (404 lines, single file)
 ```
@@ -912,7 +912,7 @@ agents/
 
 **Structure** (fictional):
 
-```
+```text
 agents/
 └── comprehensive-analyzer.md  (850 lines, single file)
 ```
@@ -938,7 +938,7 @@ agents/
 
 Refactor into directory structure:
 
-```
+```text
 comprehensive-analyzer/
 ├── comprehensive-analyzer.md  # <400 lines, core methodology
 └── references/

--- a/skills/agent-authoring/SKILL.md
+++ b/skills/agent-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-authoring
-description: Guide for authoring, designing, building, writing, and developing specialized AI agents. Use when creating, updating, reviewing, or improving agents that handle specific tasks with focused expertise. Helps design AGENT.md files, choose models (Sonnet/Haiku/Opus), define focus areas, configure tool restrictions, and decide between agents, skills, and commands. Expert in agent validation, best practices, and troubleshooting.
+description: Guide for authoring, designing, building, writing, and developing specialized AI agents. Use when creating, updating, reviewing, or improving agents that handle specific tasks with focused expertise. Helps design agent markdown files, choose models (Sonnet/Haiku/Opus), define focus areas, configure tool restrictions, and decide between agents, skills, and commands. Expert in agent validation, best practices, and troubleshooting.
 allowed-tools:
   - Read
   - Grep
@@ -188,14 +188,14 @@ Three proven patterns for building effective agents. Each pattern includes compl
 
 **Simple agent** (single file):
 
-```
+```text
 agents/
 └── agent-name.md              # <500 lines, self-contained
 ```
 
 **Complex agent** (with references):
 
-```
+```text
 agents/
 └── agent-name/
     ├── agent-name.md          # <500 lines, core workflow

--- a/skills/agent-authoring/comparison-with-official.md
+++ b/skills/agent-authoring/comparison-with-official.md
@@ -17,7 +17,7 @@ The official version has comprehensive reference on **agent triggering patterns*
 - **Implicit requests** - User hints at need ("This code is confusing")
 - **Tool usage patterns** - Triggers based on prior tool interactions
 
-**Our improvement**: Add a reference file on triggering patterns adapted to AGENT.md context.
+**Our improvement**: Add a reference file on triggering patterns adapted to agent markdown context.
 
 **Reference file**: `references/triggering-examples.md` (11,613 bytes)
 
@@ -81,7 +81,7 @@ Differences that are plugin-specific and don't apply to our context:
 
 - `color` field - Plugin-specific visual identification (not used in ~/.claude/agents/)
 - `agents/` directory - Plugin auto-discovery (we use `~/.claude/agents/`)
-- System prompt terminology - They build plugin agents with system prompts; we build AGENT.md files with focus areas and approach sections
+- System prompt terminology - They build plugin agents with system prompts; we build agent markdown files with focus areas and approach sections
 - Triggering via description field - Plugins use description for auto-triggering; our agents are manually invoked via Task tool
 
 ---
@@ -91,7 +91,7 @@ Differences that are plugin-specific and don't apply to our context:
 ### Priority 1: High Value Additions
 
 1. **Create `references/triggering-patterns.md`**
-   - Adapt their triggering examples to AGENT.md context
+   - Adapt their triggering examples to agent markdown context
    - Focus on Task tool invocation patterns
    - Include explicit/implicit/proactive scenarios
    - ~500-800 lines
@@ -127,7 +127,7 @@ Differences that are plugin-specific and don't apply to our context:
 
 1. **Create `references/system-prompt-design.md`**
    - Adapted from their system-prompt-design.md
-   - Reframe for AGENT.md approach sections
+   - Reframe for agent markdown approach sections
    - How to write effective methodology
    - Process workflow design
    - ~400-600 lines


### PR DESCRIPTION
## Summary

Improves markdown code fence formatting and documents critical validation constraint discoveries that explain why agents and skills have different structural requirements.

## Changes

### 1. Markdown Formatting Improvements

Enhanced code fence formatting across 5 documentation files:

- Add `text` language hint to code fences for better rendering
- Improves syntax highlighting consistency
- Minor description clarity fix in `skills/agent-authoring/SKILL.md`

**Files:**
- `docs/agent-vs-skill-structure.md` (5 code fences updated)
- `skills/agent-audit/resource-organization.md` (multiple code fences)
- `skills/agent-authoring/SKILL.md` (code fences + description)
- `skills/agent-authoring/comparison-with-official.md` (code fences)

### 2. Validation Constraint Documentation

**Critical Discovery**: Agent and skill structural differences are driven by validation hook behavior, not organizational preference.

Added comprehensive analysis to `references/customization/plugin-structure-comparison.md`:

**Skills: Flattened Structure Allowed**
```text
skills/skill-name/
├── SKILL.md          ← Validated for frontmatter
├── reference1.md     ← Ignored by validation
└── reference2.md     ← Ignored by validation
```

Validation logic only checks `SKILL.md` files, allowing reference files at root level.

**Agents: Subdirectory Structure Required**
```text
agents/agent-name/
├── agent-name.md     ← Validated for frontmatter
└── references/       ← Files here IGNORED by validation
    └── file.md
```

Validation logic checks ALL `.md` files in `agents/` EXCEPT those in `references/` subdirectory.

**Key Insight**: This is a **technical constraint**, not a style choice. Agents cannot use flattened structure without validation failures.

**Documentation added:**
- Validation hook behavior analysis (`hooks/validate-config.py` lines 113-119)
- Structural implications for both component types
- Cross-reference to `docs/agent-vs-skill-structure.md`

### 3. Gitignore Update

- Add `statusline/` to `.gitignore` (build artifact directory)

## Impact

- **Better documentation clarity** - Improved markdown rendering
- **Understanding validation constraints** - Explains WHY structures differ
- **Prevents future mistakes** - Documents technical requirements clearly

## Files Modified

```
.gitignore                                         |   1 +
docs/agent-vs-skill-structure.md                   |  10 +-
references/customization/plugin-structure-comparison.md | 218 +++++++++++++---
skills/agent-audit/resource-organization.md        |  40 ++--
skills/agent-authoring/SKILL.md                    |   6 +-
skills/agent-authoring/comparison-with-official.md |   8 +-
6 files changed, 198 insertions(+), 85 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)