### PR TITLE
Add argument-hint to commands that accept arguments

### DIFF
--- a/commands/audit-agent.md
+++ b/commands/audit-agent.md
@@ -1,5 +1,6 @@
 ---
 description: Validates an agent configuration for correctness, clarity, and effectiveness
+argument-hint: "[optional: agent-path]"
 ---
 
 # audit-agent

--- a/commands/audit-bash.md
+++ b/commands/audit-bash.md
@@ -1,5 +1,6 @@
 ---
 description: Audit shell scripts for best practices, security, and portability
+argument-hint: "[optional: script-path]"
 ---
 
 # audit-bash

--- a/commands/audit-command.md
+++ b/commands/audit-command.md
@@ -1,5 +1,6 @@
 ---
 description: Validates a command for delegation patterns and documentation
+argument-hint: "[optional: command-path]"
 ---
 
 # audit-command

--- a/commands/audit-hook.md
+++ b/commands/audit-hook.md
@@ -1,5 +1,6 @@
 ---
 description: Validates a hook for correctness, safety, and performance
+argument-hint: "[optional: hook-path]"
 ---
 
 # audit-hook

--- a/commands/audit-output-style.md
+++ b/commands/audit-output-style.md
@@ -1,5 +1,6 @@
 ---
 description: Validates an output-style for persona clarity and behavior specification
+argument-hint: "[optional: style-path]"
 ---
 
 # audit-output-style

--- a/commands/audit-skill.md
+++ b/commands/audit-skill.md
@@ -1,5 +1,6 @@
 ---
 description: Validates a skill for discoverability and triggering effectiveness
+argument-hint: "[optional: skill-path]"
 ---
 
 # audit-skill

--- a/commands/create-agent.md
+++ b/commands/create-agent.md
@@ -1,5 +1,6 @@
 ---
 description: Guide for authoring specialized AI agents with focused expertise and tool restrictions
+argument-hint: "[optional: agent-name]"
 ---
 
 # create-agent

--- a/commands/create-command.md
+++ b/commands/create-command.md
@@ -1,5 +1,6 @@
 ---
 description: Guide for authoring slash commands that delegate to agents or skills
+argument-hint: "[optional: command-name]"
 ---
 
 # create-command

--- a/commands/create-output-style.md
+++ b/commands/create-output-style.md
@@ -1,5 +1,6 @@
 ---
 description: Guide for authoring output-styles that transform Claude's behavior and personality
+argument-hint: "[optional: style-name]"
 ---
 
 # create-output-style

--- a/commands/create-skill.md
+++ b/commands/create-skill.md
@@ -1,5 +1,6 @@
 ---
 description: Guide for authoring effective skills that extend Claude's capabilities
+argument-hint: "[optional: skill-name]"
 ---
 
 # create-skill


### PR DESCRIPTION
## Summary

Added `argument-hint` frontmatter field to 10 commands for improved autocomplete UX and clear argument expectations. This ensures consistent documentation across all commands that accept optional arguments.

## Changes

### Commands Updated (10)

**Audit commands (6)**:
- `audit-agent.md` - `[optional: agent-path]`
- `audit-bash.md` - `[optional: script-path]`
- `audit-command.md` - `[optional: command-path]`
- `audit-hook.md` - `[optional: hook-path]`
- `audit-output-style.md` - `[optional: style-path]`
- `audit-skill.md` - `[optional: skill-path]`

**Create commands (4)**:
- `create-agent.md` - `[optional: agent-name]`
- `create-command.md` - `[optional: command-name]`
- `create-output-style.md` - `[optional: style-name]`
- `create-skill.md` - `[optional: skill-name]`

### Frontmatter Format

```yaml
---
description: Command description
argument-hint: "[optional: argument-name]"
---
```

## Benefits

- ✅ **Consistent UX**: All commands with arguments now have autocomplete hints
- ✅ **Clear expectations**: Users know what arguments are available
- ✅ **Better documentation**: Argument hints appear in command help
- ✅ **Completeness**: Addresses all 10 commands identified in audit

## Commands Not Changed (Correct)

- `audit-setup.md` - No arguments (correctly omits argument-hint)
- `automate-git.md` - No arguments (correctly omits argument-hint)
- `map-codebase.md` - Already had argument-hint field

## Testing

- [x] All 10 commands updated with consistent format
- [x] Argument hints match usage documentation in command body
- [x] Commands without arguments correctly omit field
- [x] All changes follow YAML frontmatter syntax

## Related Issues

- Resolves #94
- Part of comprehensive setup audit cleanup (#92, #93 completed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)