### PR TITLE
Add explicit model field to 5 skills (Issue #79)

### DIFF
--- a/skills/audit-bash/SKILL.md
+++ b/skills/audit-bash/SKILL.md
@@ -2,6 +2,7 @@
 name: audit-bash
 description: Comprehensive security and quality audit for shell scripts (bash, sh, zsh) using defensive programming principles and ShellCheck static analysis. Use when user asks to audit, review, check, lint, validate, or analyze shell scripts for security vulnerabilities, bugs, errors, defensive programming compliance, or best practices. Also triggers for improving script quality, finding script errors or issues, checking portability problems (macOS vs Linux), validating error handling, fixing shellcheck warnings, reviewing legacy automation scripts before release, setting up CI/CD linting infrastructure, configuring pre-commit hooks, understanding ShellCheck error codes, suppressing false positives, or ensuring script portability and quality.
 allowed-tools: [Read, Bash, Grep, Edit, Write, Glob]
+model: sonnet
 ---
 
 ## Reference Files

--- a/skills/audit-command/SKILL.md
+++ b/skills/audit-command/SKILL.md
@@ -2,6 +2,7 @@
 name: audit-command
 description: Validates command frontmatter, delegation patterns, simplicity guidelines, and documentation proportionality. Use when reviewing, auditing, analyzing, evaluating, improving, or fixing commands, validating official frontmatter (description, argument-hint, allowed-tools, model), checking delegation clarity or standalone prompts, assessing simplicity guidelines (6-15 simple, 25-80 documented), validating argument handling, or assessing documentation appropriateness. Distinguishes official Anthropic requirements from custom best practices. Also triggers when user asks about command best practices, whether a command should be a skill instead, or needs help with command structure.
 allowed-tools: [Read, Grep, Glob, Bash]
+model: sonnet
 ---
 
 ## Reference Files

--- a/skills/audit-skill/SKILL.md
+++ b/skills/audit-skill/SKILL.md
@@ -2,6 +2,7 @@
 name: audit-skill
 description: Audits skills for discoverability and triggering effectiveness. Use when analyzing skill descriptions, checking trigger phrase coverage, validating progressive disclosure, reviewing SKILL.md structure, ensuring skill discoverability, testing skill triggering, improving skill descriptions, fixing skills that aren't being invoked, debugging discovery issues, or evaluating whether a skill will be invoked appropriately. Also triggers when user asks about skill best practices, wants to improve skill discoverability, or needs help with skill structure.
 allowed-tools: [Read, Glob, Grep, Bash]
+model: sonnet
 ---
 
 ## Reference Files

--- a/skills/author-bash/SKILL.md
+++ b/skills/author-bash/SKILL.md
@@ -2,6 +2,7 @@
 name: author-bash
 description: Master of defensive Bash scripting for production automation, CI/CD pipelines, and system utilities. Expert in safe, portable, and testable shell scripts. Use when writing, creating, authoring, generating, or developing bash scripts, shell scripts, or automation. Also triggers for learning bash best practices, understanding defensive programming patterns, implementing error handling, ensuring portability, following shellcheck recommendations, or applying production-grade bash standards. Helps with CI/CD scripts, system utilities, deployment automation, and production bash code.
 allowed-tools: [Read, Edit, Write, Grep, Glob, Bash]
+model: sonnet
 ---
 
 ## Reference Files

--- a/skills/editing-assistant/SKILL.md
+++ b/skills/editing-assistant/SKILL.md
@@ -2,6 +2,7 @@
 name: editing-assistant
 description: Comprehensive text editing and improvement assistant with multiple specialized modes. Use when editing, improving, proofreading, polishing, reviewing, rewriting, or cleaning up written content. Supports fixing typos and grammar errors, checking grammar, correcting mistakes, improving flow and readability, adding punctuation, restructuring with headings, adding examples, citing sources, fact-checking, and preserving detail. Handles spelling, grammar, structure, citations, accuracy improvements, and formatting. Works with documentation, articles, markdown files, and any written content.
 allowed-tools: [Read, Edit, Grep, Glob, WebSearch]
+model: sonnet
 ---
 
 # Editing Assistant


### PR DESCRIPTION
## Summary

Adds explicit `model: sonnet` to 5 skills that were missing the model field.

## Changes

Added `model: sonnet` to:
- ✅ audit-bash
- ✅ audit-command
- ✅ audit-skill
- ✅ author-bash
- ✅ editing-assistant

## Rationale

**Why explicit model field?**
- Documents model choice for maintainers
- Enables future cost optimization
- Makes configuration explicit vs implicit defaults
- Improves consistency across all skills

**Why Sonnet?**
- Balanced capability and cost
- Appropriate for all 5 skills:
  - Audit skills require reasoning about patterns and best practices
  - Author-bash requires defensive programming guidance
  - Editing-assistant requires content improvement reasoning
- Safe default choice

## Result

All 16 skills now have explicit model specification:
- 13 skills: `model: sonnet`
- 2 skills: `model: haiku`
- 1 skill: `model: opus`

Resolves #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)