### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,27 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: weekly
+      day: monday
+      time: "03:00"
+    open-pull-requests-limit: 10
     reviewers:
-      - "philoserf"
+      - philoserf
+    labels:
+      - dependencies
+      - npm
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - philoserf
+    labels:
+      - dependencies
+      - github-actions


### PR DESCRIPTION
Configure automated dependency updates for npm and GitHub Actions.

**Changes:**
- Add .github/dependabot.yml with npm and GitHub Actions ecosystems
- Weekly schedules with 10 PR limit per ecosystem
- Reviewers and dependency labels configured