### PR TITLE
Convert single-line shell code blocks to inline code

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,7 @@ Use the `/create-*` commands for guided creation of customizations:
 
 ### Creating Agents
 
-```bash
-/create-agent [agent-name]
-```
+`/create-agent [agent-name]`
 
 Invokes the **agent-authoring** skill to guide you through:
 
@@ -144,9 +142,7 @@ Invokes the **agent-authoring** skill to guide you through:
 
 ### Creating Skills
 
-```bash
-/create-skill [skill-name]
-```
+`/create-skill [skill-name]`
 
 Invokes the **skill-authoring** skill to guide you through:
 
@@ -160,9 +156,7 @@ Invokes the **skill-authoring** skill to guide you through:
 
 ### Creating Commands
 
-```bash
-/create-command [command-name]
-```
+`/create-command [command-name]`
 
 Invokes the **command-authoring** skill to guide you through:
 
@@ -175,9 +169,7 @@ Invokes the **command-authoring** skill to guide you through:
 
 ### Creating Output-Styles
 
-```bash
-/create-output-style [style-name]
-```
+`/create-output-style [style-name]`
 
 Invokes the **output-style-authoring** skill to guide you through:
 
@@ -192,9 +184,7 @@ Invokes the **output-style-authoring** skill to guide you through:
 
 Hooks are created manually as shell scripts. Use the **hook-audit** skill for validation:
 
-```bash
-/audit-hook [hook-name]
-```
+`/audit-hook [hook-name]`
 
 **Key requirements**:
 

--- a/skills/agent-authoring/SKILL.md
+++ b/skills/agent-authoring/SKILL.md
@@ -278,9 +278,7 @@ Start by clarifying:
 
 **Check for existing agents**:
 
-```bash
-ls -la ~/.claude/agents/
-```
+`ls -la ~/.claude/agents/`
 
 Look for similar agents that might overlap.
 

--- a/skills/audit-coordinator/evaluation-criteria.md
+++ b/skills/audit-coordinator/evaluation-criteria.md
@@ -424,9 +424,7 @@ This command reads the file, parses YAML, validates fields, checks settings, gen
 
 or
 
-```bash
-#!/bin/bash
-```
+`#!/bin/bash`
 
 **JSON Input Handling**:
 

--- a/skills/bash-audit/SKILL.md
+++ b/skills/bash-audit/SKILL.md
@@ -28,15 +28,11 @@ Performs comprehensive security and quality audits of shell scripts, combining S
 
 **Find .sh files**:
 
-```bash
-find . -type f -name "*.sh"
-```
+`find . -type f -name "*.sh"`
 
 **Find executable scripts with shebang**:
 
-```bash
-find . -type f -executable -exec grep -l '^#!.*sh' {} \;
-```
+`find . -type f -executable -exec grep -l '^#!.*sh' {} \;`
 
 **Or use Glob for specific paths**:
 
@@ -48,15 +44,11 @@ find . -type f -executable -exec grep -l '^#!.*sh' {} \;
 
 **Basic ShellCheck scan**:
 
-```bash
-shellcheck --format=gcc --severity=warning <script.sh>
-```
+`shellcheck --format=gcc --severity=warning <script.sh>`
 
 **For all scripts**:
 
-```bash
-find . -name "*.sh" -exec shellcheck --format=gcc --severity=warning {} \;
-```
+`find . -name "*.sh" -exec shellcheck --format=gcc --severity=warning {} \;`
 
 **ShellCheck severity levels**:
 

--- a/skills/bash-audit/workflows.md
+++ b/skills/bash-audit/workflows.md
@@ -6,9 +6,7 @@ End-to-end examples showing complete analyze → fix → verify cycles for commo
 
 ### Step 1: Analyze
 
-```bash
-shellcheck script.sh
-```
+`shellcheck script.sh`
 
 Output:
 
@@ -82,9 +80,7 @@ chmod +x deploy.sh
 
 ### Step 2: Run ShellCheck
 
-```bash
-shellcheck deploy.sh
-```
+`shellcheck deploy.sh`
 
 Output:
 
@@ -133,15 +129,11 @@ chmod +x .git/hooks/pre-commit
 
 ### Step 1: Find All Shell Scripts
 
-```bash
-find . -name "*.sh" -type f > scripts.txt
-```
+`find . -name "*.sh" -type f > scripts.txt`
 
 ### Step 2: Run ShellCheck on All
 
-```bash
-shellcheck --format=gcc $(cat scripts.txt) > shellcheck-report.txt
-```
+`shellcheck --format=gcc $(cat scripts.txt) > shellcheck-report.txt`
 
 ### Step 3: Analyze Report
 
@@ -209,9 +201,7 @@ grep "note:" baseline.txt | wc -l     # 3
 
 Focus on "error:" level issues first:
 
-```bash
-grep "error:" baseline.txt
-```
+`grep "error:" baseline.txt`
 
 Fix these 5 critical issues, then verify:
 
@@ -313,9 +303,7 @@ git commit -m "ShellCheck: Reduced baseline from 50 to 35 violations"
 
 ### Scenario: Encounter unfamiliar error code
 
-```bash
-shellcheck script.sh
-```
+`shellcheck script.sh`
 
 Output:
 
@@ -384,9 +372,7 @@ Some ShellCheck features require specific versions:
 
 Check your version:
 
-```bash
-shellcheck --version
-```
+`shellcheck --version`
 
 Upgrade if needed:
 

--- a/skills/bash-authoring/advanced-techniques.md
+++ b/skills/bash-authoring/advanced-techniques.md
@@ -6,15 +6,11 @@ Advanced Bash patterns, dependency management, and common pitfalls to avoid.
 
 ### Error Context and Stack Traces
 
-```bash
-trap 'echo "Error at line $LINENO: exit $?" >&2' ERR
-```
+`trap 'echo "Error at line $LINENO: exit $?" >&2' ERR`
 
 Enhanced with function stack trace:
 
-```bash
-trap 'echo "Error in ${BASH_SOURCE[1]}:${BASH_LINENO[0]} (function: ${FUNCNAME[1]})" >&2' ERR
-```
+`trap 'echo "Error in ${BASH_SOURCE[1]}:${BASH_LINENO[0]} (function: ${FUNCNAME[1]})" >&2' ERR`
 
 ### Safe Temporary File Handling
 
@@ -184,15 +180,11 @@ wait $pid
 
 Wait for any background job (Bash 4.3+):
 
-```bash
-wait -n
-```
+`wait -n`
 
 List background PIDs:
 
-```bash
-jobs -p
-```
+`jobs -p`
 
 ## Conditional Execution
 
@@ -218,23 +210,17 @@ echo {A..Z}                     # Prints A B C ... Z
 
 Process items in parallel:
 
-```bash
-xargs -P $(nproc) -n 1 command < input_list
-```
+`xargs -P $(nproc) -n 1 command < input_list`
 
 Using GNU parallel (when available):
 
-```bash
-parallel -j $(nproc) command ::: arg1 arg2 arg3
-```
+`parallel -j $(nproc) command ::: arg1 arg2 arg3`
 
 ## Structured Output
 
 Generate JSON with jq:
 
-```bash
-jq -n --arg key "$value" '{key: $key}'
-```
+`jq -n --arg key "$value" '{key: $key}'`
 
 ## Performance Profiling
 
@@ -255,15 +241,11 @@ See [performance-and-optimization.md](performance-and-optimization.md) for more 
 
 **basher**:
 
-```bash
-basher install username/repo@version
-```
+`basher install username/repo@version`
 
 **bpkg**:
 
-```bash
-bpkg install username/repo -g
-```
+`bpkg install username/repo -g`
 
 ### Best Practices
 
@@ -308,15 +290,11 @@ done
 
 **Problem**:
 
-```bash
-rm -rf $dir  # WRONG: if $dir is empty, deletes everything
-```
+`rm -rf $dir  # WRONG: if $dir is empty, deletes everything`
 
 **Solution**:
 
-```bash
-rm -rf -- "$dir"
-```
+`rm -rf -- "$dir"`
 
 ### 3. Relying Solely on `set -e`
 
@@ -330,9 +308,7 @@ rm -rf -- "$dir"
 
 **Solution**: Use `printf` for reliable output:
 
-```bash
-printf '%s\n' "$data"
-```
+`printf '%s\n' "$data"`
 
 ### 5. Missing Cleanup Traps
 
@@ -349,15 +325,11 @@ tmpdir=$(mktemp -d)
 
 **Problem**:
 
-```bash
-files=($(find . -name '*.txt'))  # Breaks on spaces, newlines
-```
+`files=($(find . -name '*.txt'))  # Breaks on spaces, newlines`
 
 **Solution**:
 
-```bash
-readarray -d '' files < <(find . -name '*.txt' -print0)
-```
+`readarray -d '' files < <(find . -name '*.txt' -print0)`
 
 ### 7. Ignoring Binary-Safe File Handling
 

--- a/skills/bash-authoring/examples/1-minimal-safe-script/ANALYSIS.md
+++ b/skills/bash-authoring/examples/1-minimal-safe-script/ANALYSIS.md
@@ -10,9 +10,7 @@ This example demonstrates the **absolute minimum defensive patterns** that every
 
 **Location**: Line 20
 
-```bash
-set -euo pipefail
-```
+`set -euo pipefail`
 
 **What it does**:
 
@@ -48,9 +46,7 @@ echo "File deleted successfully"  # Never reached on error
 
 **Location**: Line 29
 
-```bash
-trap 'echo "Error on line $LINENO" >&2' ERR
-```
+`trap 'echo "Error on line $LINENO" >&2' ERR`
 
 **What it does**:
 

--- a/skills/bash-authoring/examples/3-temp-file-management/ANALYSIS.md
+++ b/skills/bash-authoring/examples/3-temp-file-management/ANALYSIS.md
@@ -4,9 +4,7 @@
 
 ### 1. Secure Temp File Creation with mktemp
 
-```bash
-TEMP_FILE=$(mktemp -t "${SCRIPT_NAME}.XXXXXXXXXX")
-```
+`TEMP_FILE=$(mktemp -t "${SCRIPT_NAME}.XXXXXXXXXX")`
 
 **Why mktemp?**
 
@@ -24,9 +22,7 @@ TEMP_FILE="/tmp/myfile.$$"  # BAD!
 
 ### 2. EXIT Trap for Guaranteed Cleanup
 
-```bash
-trap cleanup EXIT
-```
+`trap cleanup EXIT`
 
 **Why EXIT trap?**
 

--- a/skills/bash-authoring/examples/5-pipeline-safety/ANALYSIS.md
+++ b/skills/bash-authoring/examples/5-pipeline-safety/ANALYSIS.md
@@ -34,9 +34,7 @@ done < <(find . -type f -print0)
 
 ### 2. Find with xargs -0
 
-```bash
-find . -type f -print0 | xargs -0 command
-```
+`find . -type f -print0 | xargs -0 command`
 
 - `-print0`: NUL-separated output
 - `xargs -0`: Read NUL-separated input

--- a/skills/bash-authoring/patterns-and-conventions.md
+++ b/skills/bash-authoring/patterns-and-conventions.md
@@ -67,9 +67,7 @@ Core patterns and conventions for writing safe, readable, and maintainable Bash 
 
 Implement robust script directory detection:
 
-```bash
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
-```
+`SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"`
 
 ## Debugging Support
 

--- a/skills/bash-authoring/performance-and-optimization.md
+++ b/skills/bash-authoring/performance-and-optimization.md
@@ -47,15 +47,11 @@ Optimization techniques, profiling strategies, and observability patterns for hi
 
 Use `time` command for basic profiling:
 
-```bash
-time ./script.sh
-```
+`time ./script.sh`
 
 Detailed resource usage with GNU time:
 
-```bash
-/usr/bin/time -v ./script.sh
-```
+`/usr/bin/time -v ./script.sh`
 
 ### Custom Timing
 
@@ -147,9 +143,7 @@ echo "script_lines_processed $count"
 
 Include stack traces and environment info in error logs:
 
-```bash
-trap 'echo "Error at line $LINENO in $BASH_SOURCE: exit code $?" >&2' ERR
-```
+`trap 'echo "Error at line $LINENO in $BASH_SOURCE: exit code $?" >&2' ERR`
 
 ### Log Rotation
 

--- a/skills/bash-authoring/tools-and-frameworks.md
+++ b/skills/bash-authoring/tools-and-frameworks.md
@@ -51,9 +51,7 @@ go install mvdan.cc/sh/v3/cmd/shfmt@latest
 
 **Standard Configuration**:
 
-```bash
-shfmt -i 2 -ci -bn -sr -kp script.sh
-```
+`shfmt -i 2 -ci -bn -sr -kp script.sh`
 
 Flags:
 
@@ -65,9 +63,7 @@ Flags:
 
 **Format all scripts**:
 
-```bash
-shfmt -w *.sh
-```
+`shfmt -w *.sh`
 
 ### checkbashisms
 
@@ -82,9 +78,7 @@ brew install checkbashisms        # macOS
 
 **Usage**:
 
-```bash
-checkbashisms script.sh
-```
+`checkbashisms script.sh`
 
 ### Semgrep
 
@@ -99,9 +93,7 @@ pip install semgrep               # Python
 
 **Usage**:
 
-```bash
-semgrep --config=auto script.sh
-```
+`semgrep --config=auto script.sh`
 
 ### CodeQL
 
@@ -122,9 +114,7 @@ npm install -g bats               # npm
 
 **Usage**:
 
-```bash
-bats test/*.bats
-```
+`bats test/*.bats`
 
 **Example test**:
 
@@ -153,15 +143,11 @@ BDD-style testing framework with rich assertions.
 
 **Installation**:
 
-```bash
-curl -fsSL https://git.io/shellspec | sh
-```
+`curl -fsSL https://git.io/shellspec | sh`
 
 **Usage**:
 
-```bash
-shellspec
-```
+`shellspec`
 
 **Example**:
 
@@ -180,9 +166,7 @@ xUnit-style testing framework.
 
 **Installation**:
 
-```bash
-brew install shunit2              # macOS
-```
+`brew install shunit2              # macOS`
 
 **Example**:
 
@@ -212,9 +196,7 @@ CLI framework generator for building command-line applications.
 
 **Installation**:
 
-```bash
-gem install bashly
-```
+`gem install bashly`
 
 **Usage**:
 
@@ -231,15 +213,11 @@ Bash package manager for dependency management.
 
 **Installation**:
 
-```bash
-git clone https://github.com/basherpm/basher.git ~/.basher
-```
+`git clone https://github.com/basherpm/basher.git ~/.basher`
 
 **Usage**:
 
-```bash
-basher install username/repo@version
-```
+`basher install username/repo@version`
 
 ### bpkg
 
@@ -247,15 +225,11 @@ Alternative bash package manager with npm-like interface.
 
 **Installation**:
 
-```bash
-curl -sLo- https://get.bpkg.sh | bash
-```
+`curl -sLo- https://get.bpkg.sh | bash`
 
 **Usage**:
 
-```bash
-bpkg install username/repo -g
-```
+`bpkg install username/repo -g`
 
 ### shdoc
 
@@ -263,15 +237,11 @@ Generate markdown documentation from shell script comments.
 
 **Installation**:
 
-```bash
-brew install shdoc                # macOS
-```
+`brew install shdoc                # macOS`
 
 **Usage**:
 
-```bash
-shdoc < script.sh > README.md
-```
+`shdoc < script.sh > README.md`
 
 **Comment format**:
 
@@ -291,9 +261,7 @@ Generate man pages from shell scripts.
 
 **Installation**:
 
-```bash
-pip install shellman
-```
+`pip install shellman`
 
 **Usage**:
 
@@ -317,9 +285,7 @@ pip install pre-commit            # Python
 
 **Setup**:
 
-```bash
-pre-commit install
-```
+`pre-commit install`
 
 See [documentation-and-ci-cd.md](documentation-and-ci-cd.md) for configuration examples.
 
@@ -329,15 +295,11 @@ GitHub Actions workflow linter.
 
 **Installation**:
 
-```bash
-brew install actionlint           # macOS
-```
+`brew install actionlint           # macOS`
 
 **Usage**:
 
-```bash
-actionlint
-```
+`actionlint`
 
 ### gitleaks
 
@@ -345,9 +307,7 @@ Secrets scanning to prevent credential leaks.
 
 **Installation**:
 
-```bash
-brew install gitleaks             # macOS
-```
+`brew install gitleaks             # macOS`
 
 **Usage**:
 

--- a/skills/command-audit/audit-workflow-steps.md
+++ b/skills/command-audit/audit-workflow-steps.md
@@ -124,9 +124,7 @@ Evaluate based on:
 
 **Check file size and complexity** (BEST PRACTICE GUIDELINES):
 
-```bash
-wc -l commands/audit-agent.md
-```
+`wc -l commands/audit-agent.md`
 
 **Guidelines** (not hard limits):
 

--- a/skills/command-authoring/command-creation-process.md
+++ b/skills/command-authoring/command-creation-process.md
@@ -13,9 +13,7 @@ See [command-design-patterns.md](command-design-patterns.md) for pattern details
 
 **Check existing commands**:
 
-```bash
-ls -la ~/.claude/commands/
-```
+`ls -la ~/.claude/commands/`
 
 ## Step 2: Choose Command Pattern
 

--- a/skills/command-authoring/command-design-patterns.md
+++ b/skills/command-authoring/command-design-patterns.md
@@ -71,9 +71,7 @@ Runs multiple quality checks on the codebase.
 
 ## Usage
 
-```bash
-/quality-check [path]
-```
+`/quality-check [path]`
 ````
 
 - **With path**: Checks the specified directory

--- a/skills/command-authoring/command-examples.md
+++ b/skills/command-authoring/command-examples.md
@@ -36,9 +36,7 @@ Validates a sub-agent configuration file for correctness, clarity, and effective
 
 ## Usage
 
-```bash
-/validate-claude-agent [agent-name]
-```
+`/validate-claude-agent [agent-name]`
 ````
 
 - **With agent-name**: Validates the specified agent

--- a/skills/git-workflow/evaluations/messy-history.md
+++ b/skills/git-workflow/evaluations/messy-history.md
@@ -43,9 +43,7 @@ Commits exist, no new commits to create
 
 1. **Check push status**:
 
-   ```bash
-   git log origin/feature/authentication..HEAD
-   ```
+`   git log origin/feature/authentication..HEAD`
 
    Shows 6 unpushed commits - safe to rebase
 

--- a/skills/git-workflow/examples.md
+++ b/skills/git-workflow/examples.md
@@ -601,9 +601,7 @@ User confirms cleanup
 
 "To clean up this history, I recommend running this command manually:
 
-```bash
-git rebase -i HEAD~7
-```
+`git rebase -i HEAD~7`
 
 Then in the editor, change the rebase plan to:
 
@@ -1000,9 +998,7 @@ User chooses A (squash).
 
 Reset to before the three commits:
 
-```bash
-git reset --soft HEAD~3
-```
+`git reset --soft HEAD~3`
 
 All changes now staged. Create single well-formed commit:
 
@@ -1073,9 +1069,7 @@ User selects 2 (skip tests this time).
 
 Proceed to Phase 5 with clean commit:
 
-```bash
-git push -u origin feature/user-auth
-```
+`git push -u origin feature/user-auth`
 
 Success!
 
@@ -1250,9 +1244,7 @@ Proceeding to Phase 5...
 
 Protected branch check (none - on feature branch), then:
 
-```bash
-git push -u origin feature/api-retry
-```
+`git push -u origin feature/api-retry`
 
 Success!
 

--- a/skills/git-workflow/examples/minimal-feature-commit/workflow-execution.md
+++ b/skills/git-workflow/examples/minimal-feature-commit/workflow-execution.md
@@ -49,9 +49,7 @@ git log -1 --stat
 
 ## Phase 5: Push
 
-```bash
-git push -u origin feature/add-logging
-```
+`git push -u origin feature/add-logging`
 
 ## Done
 

--- a/skills/git-workflow/protected-branch-protocol.md
+++ b/skills/git-workflow/protected-branch-protocol.md
@@ -594,9 +594,7 @@ If you're unsure about the state or recovery:
 
 Protected branches can be configured in the skill. Default list:
 
-```bash
-PROTECTED_BRANCHES=("main" "master" "develop" "production" "staging")
-```
+`PROTECTED_BRANCHES=("main" "master" "develop" "production" "staging")`
 
 **Future enhancement**: Could read from:
 

--- a/skills/git-workflow/rebase-guide.md
+++ b/skills/git-workflow/rebase-guide.md
@@ -362,15 +362,11 @@ Sometimes rebasing causes conflicts. Don't panic!
 
 2. **Stage resolved files**
 
-   ```bash
-   git add file.js
-   ```
+`   git add file.js`
 
 3. **Continue rebase**
 
-   ```bash
-   git rebase --continue
-   ```
+`   git rebase --continue`
 
 4. **Or abort if needed**
 

--- a/skills/git-workflow/workflow-phases.md
+++ b/skills/git-workflow/workflow-phases.md
@@ -471,9 +471,7 @@ fi
 
 3. Show summary of commits to be pushed:
 
-   ```bash
-   git log origin/<branch>..HEAD --oneline
-   ```
+`   git log origin/<branch>..HEAD --oneline`
 
    (or just `git log --oneline -n <count>` if new branch)
 

--- a/skills/hook-audit/SKILL.md
+++ b/skills/hook-audit/SKILL.md
@@ -364,9 +364,7 @@ All hooks MUST use the correct shebang line for their language. Different sheban
 
 **All bash hooks MUST use**:
 
-```bash
-#!/bin/bash
-```
+`#!/bin/bash`
 
 **NOT**:
 

--- a/skills/map-codebase/workflow.md
+++ b/skills/map-codebase/workflow.md
@@ -25,9 +25,7 @@ Documents are reference material for Claude when planning/executing. Vague descr
 
 Check if .planning/codebase/ already exists:
 
-```bash
-ls -la .planning/codebase/ 2>/dev/null
-```
+`ls -la .planning/codebase/ 2>/dev/null`
 
 **If exists:**
 
@@ -55,9 +53,7 @@ Continue to create_structure.
 
 Create .planning/codebase/ directory:
 
-```bash
-mkdir -p .planning/codebase
-```
+`mkdir -p .planning/codebase`
 
 **Expected output files:**
 

--- a/skills/organize-folders/document-collection-organization.md
+++ b/skills/organize-folders/document-collection-organization.md
@@ -114,9 +114,7 @@ When adding unknown PDFs to your collection, use this standard workflow to deter
 
 ### Step 1: Extract Metadata
 
-```bash
-pdfinfo filename.pdf
-```
+`pdfinfo filename.pdf`
 
 Look for:
 
@@ -130,9 +128,7 @@ Look for:
 
 ### Step 2: Sample Content
 
-```bash
-pdftotext filename.pdf - | head -50
-```
+`pdftotext filename.pdf - | head -50`
 
 Examine first 50 lines for:
 

--- a/skills/skill-authoring/SKILL.md
+++ b/skills/skill-authoring/SKILL.md
@@ -217,9 +217,7 @@ When creating a new skill from scratch, always run the `init_skill.py` script. T
 
 Usage:
 
-```bash
-scripts/init_skill.py <skill-name> --path <output-directory>
-```
+`scripts/init_skill.py <skill-name> --path <output-directory>`
 
 The script:
 
@@ -294,15 +292,11 @@ Write instructions for using the skill and its bundled resources.
 
 Once development of the skill is complete, it must be packaged into a distributable .skill file that gets shared with the user. The packaging process automatically validates the skill first to ensure it meets all requirements:
 
-```bash
-scripts/package_skill.py <path/to/skill-folder>
-```
+`scripts/package_skill.py <path/to/skill-folder>`
 
 Optional output directory specification:
 
-```bash
-scripts/package_skill.py <path/to/skill-folder> ./dist
-```
+`scripts/package_skill.py <path/to/skill-folder> ./dist`
 
 The packaging script will:
 

--- a/skills/skill-authoring/complete-example.md
+++ b/skills/skill-authoring/complete-example.md
@@ -192,8 +192,6 @@ black uses [tool.black] section in pyproject.toml
 
 **Repackage**:
 
-```bash
-python scripts/package_skill.py code-formatter
-```
+`python scripts/package_skill.py code-formatter`
 
 **Result**: Improved skill that handles configuration-aware formatting.

--- a/skills/uv-package-manager/command-reference.md
+++ b/skills/uv-package-manager/command-reference.md
@@ -369,9 +369,7 @@ uv export --format requirements-txt --no-dev > requirements.txt
 ## Tips and Tricks
 
 **Always use --frozen in CI:**
-```bash
-uv sync --frozen  # Exact reproduction
-```
+`uv sync --frozen  # Exact reproduction`
 
 **Prefer uv run over activation:**
 ```bash

--- a/skills/uv-package-manager/installation-setup.md
+++ b/skills/uv-package-manager/installation-setup.md
@@ -4,9 +4,7 @@
 
 ### macOS/Linux (Recommended)
 
-```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
+`curl -LsSf https://astral.sh/uv/install.sh | sh`
 
 ### Windows (PowerShell)
 

--- a/skills/uv-package-manager/migration-guide.md
+++ b/skills/uv-package-manager/migration-guide.md
@@ -44,9 +44,7 @@ uv sync
 ### Migration Steps
 
 1. **Initialize uv configuration:**
-   ```bash
-   uv init .
-   ```
+`   uv init .`
 
 2. **Import existing requirements:**
    ```bash
@@ -169,9 +167,7 @@ uv run pytest
    ```
 
 3. **Update lock file:**
-   ```bash
-   uv lock
-   ```
+`   uv lock`
 
 4. **Remove Poetry:**
    ```bash
@@ -258,9 +254,7 @@ uv sync
    ```
 
 2. **Generate lockfile:**
-   ```bash
-   uv lock
-   ```
+`   uv lock`
 
 3. **Test installation:**
    ```bash
@@ -460,9 +454,7 @@ COPY . .
    - Distribute documentation
 
 2. **Install UV on developer machines:**
-   ```bash
-   curl -LsSf https://astral.sh/uv/install.sh | sh
-   ```
+`   curl -LsSf https://astral.sh/uv/install.sh | sh`
 
 3. **Migrate one project together:**
    - Live migration session


### PR DESCRIPTION
Replace three-line shell code blocks with a single line of content with backtick-style inline code formatting for improved readability.

Applies to ```shell, ```bash, ```sh, ```zsh, and ```fish blocks only.

Affected 30 documentation files across skills and references.