### PR TITLE
Add /audit command and clarify evaluator role

### DIFF
--- a/agents/evaluator/evaluator.md
+++ b/agents/evaluator/evaluator.md
@@ -1,6 +1,6 @@
 ---
 name: evaluator
-description: Evaluates Claude Code customizations for correctness, clarity, and effectiveness. Expert in YAML validation, markdown formatting, tool permission analysis, and best practices for agents, commands, skills, hooks, and output-styles.
+description: Quick structural validation of Claude Code customizations. Checks YAML syntax, required fields, naming conventions, and file organization. Use for fast correctness checks; use specialized *-audit skills for deep best-practices analysis.
 model: claude-sonnet-4-5-20250929
 allowed_tools:
   - Read

--- a/commands/audit.md
+++ b/commands/audit.md
@@ -1,0 +1,37 @@
+---
+description: Audit Claude Code customizations for quality and correctness
+---
+
+# audit
+
+Comprehensive audit of Claude Code customizations (agents, skills, commands, hooks, output-styles).
+
+## Usage
+
+`/audit [target] [scope]`
+
+- **target**: Specific file, type ("skills", "hooks", "agents"), or "setup" for everything
+- **scope**: "local" (.claude/), "personal" (~/.claude/), or "full" (both, default)
+
+## Examples
+
+```text
+/audit                     # Full audit of entire setup
+/audit skills              # Audit all skills
+/audit my-skill            # Audit specific skill
+/audit setup local         # Audit only project .claude/
+/audit hooks personal      # Audit only ~/.claude/hooks/
+```
+
+## Delegation
+
+This command invokes the **audit-coordinator** skill, which orchestrates specialized auditors:
+
+- **audit-skill** - Skill discoverability and triggering
+- **audit-agent** - Agent model selection and tool permissions
+- **audit-hook** - Hook safety, exit codes, error handling
+- **audit-command** - Command simplicity and delegation
+- **audit-output-style** - Persona and behavior clarity
+- **evaluator** - General structural validation (YAML, fields, format)
+
+Reports are prioritized: Critical > Important > Nice-to-Have.


### PR DESCRIPTION
## Summary

- Add `/audit` command as a clear user entry point for auditing Claude Code customizations
- Clarify evaluator agent description to distinguish from specialized `*-audit` skills:
  - **evaluator**: Quick structural validation (YAML syntax, required fields, naming conventions)
  - **\*-audit skills**: Deep best-practices analysis for specific component types

## Context

The audit ecosystem had overlapping descriptions that made it unclear when to use which component. This change:
1. Gives users an explicit `/audit` command to invoke
2. Sharpens the distinction between quick validation (evaluator) and deep analysis (*-audit skills)

## Test plan

- [ ] Run `/help` and verify `/audit` appears
- [ ] Run `/audit` on a sample skill to verify it works
- [ ] Verify evaluator description reflects its focused role

🤖 Generated with [Claude Code](https://claude.com/claude-code)