### PR TITLE
Fix allowed-tools format in git-workflow skill

### DIFF
--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: git-workflow
 description: Automates git workflows with branch management, atomic commits, history cleanup, and PRs. Use when committing, pushing, creating PRs, cleaning up commits, or organizing git changes with best practices.
-allowed-tools: Read, Bash, AskUserQuestion, TodoWrite
+allowed-tools: [Read, Bash, AskUserQuestion, TodoWrite]
 model: inherit
 ---
 


### PR DESCRIPTION
## Summary
- Convert `allowed-tools` from string format to array format in git-workflow skill
- Aligns with the standard format used by other skills in the project

Fixes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)