### PR TITLE
docs: add agent hooks documentation to authoring and audit skills

### DIFF
--- a/references/frontmatter-requirements.md
+++ b/references/frontmatter-requirements.md
@@ -18,6 +18,12 @@ tools: Read, Edit, Bash # Optional: restricts available tools
 model: sonnet # Optional: sonnet, haiku, opus, or inherit
 permissionMode: default # Optional: default, acceptEdits, bypassPermissions, plan, ignore
 skills: skill1, skill2 # Optional: auto-load skills when agent starts
+hooks: # Optional: lifecycle hooks scoped to this agent
+  PostToolUse:
+    - matcher: "Edit|Write"
+      hooks:
+        - type: command
+          command: "./scripts/format.sh"
 ---
 ```
 
@@ -32,6 +38,7 @@ skills: skill1, skill2 # Optional: auto-load skills when agent starts
 - **model**: Which Claude model to use
 - **permissionMode**: How to handle permissions
 - **skills**: Comma-separated list of skills to auto-load
+- **hooks**: Lifecycle hooks scoped to this agent (PreToolUse, PostToolUse, Stop)
 
 ### Model Options
 

--- a/references/hook-events.md
+++ b/references/hook-events.md
@@ -14,6 +14,53 @@ Comprehensive guide to Claude Code hook events and configuration.
 | `Stop`              | Agent stops             | No           | Cleanup, notifications             |
 | `SubagentStop`      | Subagent completes      | No           | Result processing, logging         |
 
+## Agent-Level Hooks
+
+Hooks can be defined in agent YAML frontmatter, scoping them to that specific agent only.
+
+### Supported Events (Agent-Level)
+
+| Event         | Trigger                | Use Case                                |
+| ------------- | ---------------------- | --------------------------------------- |
+| `PreToolUse`  | Before agent uses tool | Validation, blocking, logging           |
+| `PostToolUse` | After tool completes   | Formatting, notifications               |
+| `Stop`        | Agent finishes         | Cleanup (auto-converts to SubagentStop) |
+
+### Agent vs Settings Hooks
+
+| Aspect | Agent-Level (frontmatter)       | Settings-Level (settings.json)          |
+| ------ | ------------------------------- | --------------------------------------- |
+| Scope  | Single agent only               | All sessions/agents                     |
+| Events | PreToolUse, PostToolUse, Stop   | All events including SubagentStart/Stop |
+| Use    | Agent needs specific validation | Global behavior needed                  |
+
+### Agent Hook Example
+
+```yaml
+---
+name: code-reviewer
+description: Review code changes with automatic linting
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/validate-command.sh"
+  PostToolUse:
+    - matcher: "Edit|Write"
+      hooks:
+        - type: command
+          command: "./scripts/run-linter.sh"
+---
+```
+
+### Key Characteristics
+
+- **Component-scoped**: Only run when that specific agent is active
+- **Automatic cleanup**: Cleaned up when agent finishes
+- **Same format**: Follows settings.json hook configuration format
+- **Matchers**: Filter which tools trigger the hooks
+
 ## Configuration Pattern
 
 ### Basic Hook

--- a/rules/markdown.md
+++ b/rules/markdown.md
@@ -5,7 +5,7 @@ paths:
 
 - Must pass `prettier` and `markdownlint`
 - Run `bunx prettier --write <file>` to format
-- Run `bunx markdownlint-cli2 <file>` to validate
+- Run `bunx markdownlint <file>` to validate
 - **MD041**: Every code block must have a language tag (e.g., ` ```bash `, ` ```ts `, ` ```json `); use `text` when no other applies
 - **MD013**: Line length is not enforced
 - Always specify language tags: `bash`, `sh`, `ts`, `tsx`, `js`, `json`, `yaml`, `python`, `sql`, `html`, `css`, etc.

--- a/rules/python.md
+++ b/rules/python.md
@@ -5,6 +5,7 @@ paths:
 
 - Use `uv` exclusively (never pip/poetry/pipenv); use `uvx` for PyPI tools
 - Self-contained scripts must use PEP 723 inline dependencies:
+
 ```python
 #!/usr/bin/env python3
 # /// script
@@ -15,6 +16,7 @@ paths:
 import requests
 import click
 ```
+
 - Run with: `uvx --script <file.py>`
 - Use Black for formatting and Ruff for linting
 - Use type hints for function signatures

--- a/rules/typescript.md
+++ b/rules/typescript.md
@@ -10,7 +10,7 @@ paths:
 
 - Use `bunx` for external tools, `bun run` for scripts, `bun install` for dependencies—never npm/yarn
 - Target Bun as the runtime; use Bun's native APIs where applicable (file I/O, testing, bundling)
-- Use Bun's native test runner with `bun test` for all test files (_.test.ts, _.spec.ts)
+- Use Bun's native test runner with `bun test` for all test files (_.test.ts,_.spec.ts)
 - Biome is the single source of truth for formatting and linting
 - Follow biome.json configuration exactly; do not suggest overrides without explicit request
 - Run `biome check --fix` or `biome format --write` via `bun run` when changes are needed

--- a/skills/agent-audit/SKILL.md
+++ b/skills/agent-audit/SKILL.md
@@ -56,6 +56,7 @@ Must be fixed for agent to function correctly:
 - [ ] **At least 3 focus areas** - Minimum viable expertise definition
 - [ ] **Tool restrictions present** - allowed_tools or allowed-patterns specified
 - [ ] **No security vulnerabilities** - Tools don't expose dangerous capabilities
+- [ ] **Hooks valid (if present)** - Valid event types, proper matcher syntax
 
 ### Important Issues
 
@@ -144,6 +145,36 @@ allowed_tools:
 - **Orchestrator**: [Task, Skill, Read, AskUserQuestion]
 
 See [tool-restrictions.md](tool-restrictions.md) for security analysis.
+
+### Step 3.5: Validate Hooks Configuration (if present)
+
+**Check hooks field** (optional):
+
+```yaml
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/validate.sh"
+```
+
+**Validation checklist**:
+
+1. **Valid event types**: Only PreToolUse, PostToolUse, Stop allowed
+2. **Valid matcher patterns**: Proper regex syntax, matches actual tools
+3. **Command exists**: Hook scripts are present and executable
+4. **Security review**: No dangerous commands, credentials access, or network calls
+5. **Timeout appropriate**: <30s recommended
+
+**Common issues**:
+
+- Invalid event (e.g., SessionStart not allowed in agent hooks)
+- Matcher doesn't match any tools the agent uses
+- Hook script missing or not executable
+- Command runs dangerous operations
+
+See [tool-restrictions.md](tool-restrictions.md) for hooks security considerations.
 
 ### Step 4: Assess Focus Area Quality
 

--- a/skills/agent-audit/tool-restrictions.md
+++ b/skills/agent-audit/tool-restrictions.md
@@ -714,3 +714,84 @@ allowed_tools:
 - Orchestrator: [Task, Skill, Read, AskUserQuestion]
 
 **When in doubt**: Start restrictive, add tools as needed.
+
+## Hooks Security Considerations
+
+Agent-level hooks run with user credentials (same security model as settings.json hooks).
+
+### Security Review Checklist
+
+When auditing agent hooks:
+
+- [ ] **Commands reviewed**: All hook commands are safe and necessary
+- [ ] **No network calls**: Hooks don't make external requests (unless justified)
+- [ ] **No credential access**: Hooks don't read .env, secrets, or credentials
+- [ ] **Timeout set**: Commands have reasonable timeouts (<30s)
+- [ ] **Exit codes handled**: Script uses proper exit codes (0=allow, 2=block)
+- [ ] **Error handling**: Script fails safely (exit 0 on errors unless blocking)
+
+### Red Flags
+
+**Dangerous patterns** to flag during audit:
+
+```yaml
+# ❌ Network access
+hooks:
+  PostToolUse:
+    - hooks:
+        - type: command
+          command: "curl https://external-server.com/report"
+
+# ❌ Credential access
+hooks:
+  PreToolUse:
+    - hooks:
+        - type: command
+          command: "cat ~/.env | grep API_KEY"
+
+# ❌ No timeout (could hang indefinitely)
+hooks:
+  PostToolUse:
+    - hooks:
+        - type: command
+          command: "./slow-script.sh"
+          # Missing timeout!
+```
+
+**Safe patterns**:
+
+```yaml
+# ✓ Local validation with timeout
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/validate-command.sh"
+          timeout: 5
+
+# ✓ Auto-format with standard tools
+hooks:
+  PostToolUse:
+    - matcher: "Edit|Write"
+      hooks:
+        - type: command
+          command: "prettier --write \"$TOOL_FILE_PATH\""
+          timeout: 10
+```
+
+### Exit Code Semantics
+
+| Exit Code | Meaning                | When to Use                    |
+| --------- | ---------------------- | ------------------------------ |
+| 0         | Allow (success)        | Default, allow tool to proceed |
+| 2         | Block with message     | Validation failed, stop tool   |
+| Other     | Error (allow but warn) | Unexpected error, don't block  |
+
+### Recommendations
+
+1. **Keep hooks simple**: Validation, formatting, logging only
+2. **Set timeouts**: Always specify timeout (5-30s typical)
+3. **Fail safely**: Exit 0 on errors unless intentionally blocking
+4. **Review commands**: Audit all shell commands before deployment
+5. **Test locally**: Verify hook behavior before using in production

--- a/skills/agent-authoring/SKILL.md
+++ b/skills/agent-authoring/SKILL.md
@@ -170,6 +170,59 @@ Example: When agent only needs to read and ask questions
 
 **Most agents use default** - only use others when you have a specific workflow need.
 
+### 5. Agent Hooks
+
+Agent hooks are lifecycle hooks defined in YAML frontmatter, scoped to that specific agent.
+
+**When to use agent hooks**:
+
+- Agent needs specific validation before tool execution
+- Auto-format or lint files after agent edits
+- Log or notify when agent completes tasks
+- Need behavior specific to one agent, not global
+
+**When to use settings.json hooks instead**:
+
+- Behavior applies to all sessions/agents
+- Need events like SessionStart, SubagentStart, UserPromptSubmit
+- Global validation or formatting rules
+
+**Available events**:
+
+| Event         | Trigger                | Use Case                      |
+| ------------- | ---------------------- | ----------------------------- |
+| `PreToolUse`  | Before agent uses tool | Validation, blocking, logging |
+| `PostToolUse` | After tool completes   | Formatting, notifications     |
+| `Stop`        | Agent finishes         | Cleanup, notifications        |
+
+**Configuration syntax**:
+
+```yaml
+---
+name: code-reviewer
+description: Review code with automatic linting
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/validate-command.sh"
+  PostToolUse:
+    - matcher: "Edit|Write"
+      hooks:
+        - type: command
+          command: "./scripts/run-linter.sh"
+          timeout: 10
+---
+```
+
+**Key points**:
+
+- **Matchers** filter which tools trigger hooks (`"Edit|Write"`, `"Bash"`, `"*"`)
+- **Stop** event auto-converts to SubagentStop internally
+- Hooks run with user credentials (same security model as settings.json)
+- Keep hook scripts fast (<30s timeout recommended)
+
 ## Agent Design Patterns
 
 Three proven patterns for building effective agents. Each pattern includes complete templates you can copy and customize.

--- a/skills/agent-authoring/design-patterns.md
+++ b/skills/agent-authoring/design-patterns.md
@@ -44,6 +44,17 @@ allowed_tools:
 - [How it reports findings]
 ```
 
+**Optional: Add hooks for input validation**:
+
+```yaml
+hooks:
+  PreToolUse:
+    - matcher: "Read"
+      hooks:
+        - type: command
+          command: "./scripts/validate-file-path.sh"
+```
+
 ---
 
 ## Pattern 2: Code Generator/Modifier
@@ -87,6 +98,18 @@ allowed_tools:
 - [Design principles followed]
 - [Code patterns used]
 - [Quality standards applied]
+```
+
+**Optional: Add hooks for auto-formatting**:
+
+```yaml
+hooks:
+  PostToolUse:
+    - matcher: "Edit|Write"
+      hooks:
+        - type: command
+          command: "prettier --write \"$TOOL_FILE_PATH\""
+          timeout: 10
 ```
 
 ---

--- a/skills/command-audit/INDEX.md
+++ b/skills/command-audit/INDEX.md
@@ -190,18 +190,18 @@ reference file based on your use case.
 
 ## Reference File Quick Reference
 
-| File                                                                            | Primary Use      | Lines | Key Topics                      |
-| ------------------------------------------------------------------------------- | ---------------- | ----- | ------------------------------- |
-| [audit-checklist.md](audit-checklist.md)                                        | Quick validation | ~90   | Checklist items, prioritization |
-| [audit-workflow-steps.md](audit-workflow-steps.md)                              | Detailed process | ~290  | 7-step workflow, validation     |
-| [common-issues-and-antipatterns.md](common-issues-and-antipatterns.md)          | Fix problems     | ~380  | 9 issue patterns, fixes         |
-| [frontmatter-validation.md](frontmatter-validation.md)                          | Frontmatter      | ~150  | Official fields, validation     |
-| [delegation-patterns.md](../../references/delegation-patterns.md) | Patterns         | ~200  | 4 valid patterns, examples      |
-| [simplicity-enforcement.md](simplicity-enforcement.md)                          | Complexity       | ~250  | Guidelines, skill migration     |
-| [argument-handling.md](argument-handling.md)                                    | Arguments        | ~180  | Patterns, defaults, validation  |
-| [documentation-proportionality.md](documentation-proportionality.md)            | Docs levels      | ~160  | Minimal vs full docs            |
-| [report-format.md](report-format.md)                                            | Report structure | ~120  | Template, sections, scoring     |
-| [examples.md](examples.md)                                                      | Examples         | ~400  | Good/poor commands, audits      |
+| File                                                                   | Primary Use      | Lines | Key Topics                      |
+| ---------------------------------------------------------------------- | ---------------- | ----- | ------------------------------- |
+| [audit-checklist.md](audit-checklist.md)                               | Quick validation | ~90   | Checklist items, prioritization |
+| [audit-workflow-steps.md](audit-workflow-steps.md)                     | Detailed process | ~290  | 7-step workflow, validation     |
+| [common-issues-and-antipatterns.md](common-issues-and-antipatterns.md) | Fix problems     | ~380  | 9 issue patterns, fixes         |
+| [frontmatter-validation.md](frontmatter-validation.md)                 | Frontmatter      | ~150  | Official fields, validation     |
+| [delegation-patterns.md](../../references/delegation-patterns.md)      | Patterns         | ~200  | 4 valid patterns, examples      |
+| [simplicity-enforcement.md](simplicity-enforcement.md)                 | Complexity       | ~250  | Guidelines, skill migration     |
+| [argument-handling.md](argument-handling.md)                           | Arguments        | ~180  | Patterns, defaults, validation  |
+| [documentation-proportionality.md](documentation-proportionality.md)   | Docs levels      | ~160  | Minimal vs full docs            |
+| [report-format.md](report-format.md)                                   | Report structure | ~120  | Template, sections, scoring     |
+| [examples.md](examples.md)                                             | Examples         | ~400  | Good/poor commands, audits      |
 
 ## Workflow Recommendations
 

--- a/skills/hook-audit/comparison-with-official.md
+++ b/skills/hook-audit/comparison-with-official.md
@@ -622,7 +622,7 @@ From official hook-development skill:
 | Commands           | author-command ✅      | audit-command ✅      | Complete pair  |
 | Output Styles      | author-output-style ✅ | audit-output-style ✅ | Complete pair  |
 | Hooks              | **❌ Missing**         | audit-hook ✅         | **Incomplete** |
-| Bash Scripts       | hook-authoring ✅         | audit-hook ✅         | Complete pair  |
+| Bash Scripts       | hook-authoring ✅      | audit-hook ✅         | Complete pair  |
 
 **Natural workflow broken:** Without hook-authoring, users lack guidance on:
 

--- a/skills/map-codebase/SKILL.md
+++ b/skills/map-codebase/SKILL.md
@@ -14,15 +14,18 @@ allowed-tools:
 ## Reference Files
 
 **Workflow & Process:**
+
 - [workflow.md](workflow.md) — Detailed orchestration and guidance
 
 **Core Templates** (always use):
+
 - [templates/stack.md](templates/stack.md) — STACK.md
 - [templates/architecture.md](templates/architecture.md) — ARCHITECTURE.md
 - [templates/structure.md](templates/structure.md) — STRUCTURE.md
 - [templates/conventions.md](templates/conventions.md) — CONVENTIONS.md
 
 **Optional Templates** (use as applicable):
+
 - [templates/testing.md](templates/testing.md) — TESTING.md (if tests exist)
 - [templates/integrations.md](templates/integrations.md) — INTEGRATIONS.md (if external services)
 - [templates/concerns.md](templates/concerns.md) — CONCERNS.md (if complex project)

--- a/skills/map-codebase/templates/architecture.md
+++ b/skills/map-codebase/templates/architecture.md
@@ -251,6 +251,7 @@ _Update when major patterns change_
 - Cross-cutting concerns (logging, auth, validation)
 
 **What does NOT belong:**
+
 - Exhaustive file listings (see STRUCTURE.md)
 - Technology choices (see STACK.md)
 - Line-by-line code walkthroughs

--- a/skills/map-codebase/templates/stack.md
+++ b/skills/map-codebase/templates/stack.md
@@ -187,6 +187,7 @@ _Update after major dependency changes_
 - Platform/deployment requirements
 
 **What does NOT belong:**
+
 - File structure (see STRUCTURE.md)
 - Architectural patterns (see ARCHITECTURE.md)
 - Every dependency (only critical ones)

--- a/skills/map-codebase/templates/structure.md
+++ b/skills/map-codebase/templates/structure.md
@@ -284,6 +284,7 @@ _Update when directory structure changes_
 - Special/generated directories
 
 **What does NOT belong:**
+
 - Conceptual architecture (see ARCHITECTURE.md)
 - Technology stack (see STACK.md)
 - Code implementation details


### PR DESCRIPTION
Document the new agent hooks feature that allows hooks to be defined in agent YAML frontmatter for lifecycle events scoped to that agent.

Changes:
- Add hooks field to frontmatter-requirements.md subagent spec
- Add Agent-Level Hooks section to hook-events.md reference
- Add Agent Hooks section to agent-authoring skill
- Add hooks examples to design-patterns.md templates
- Add hooks validation to agent-audit checklist and workflow
- Add Hooks Security Considerations to tool-restrictions.md
- Update markdown.md rule (paths frontmatter, markdownlint command)
- Various format improvements to rules and map-codebase templates