### PR TITLE
docs: add cross-reference to matcher syntax in agent-authoring skill

### DIFF
--- a/skills/agent-authoring/SKILL.md
+++ b/skills/agent-authoring/SKILL.md
@@ -223,6 +223,8 @@ hooks:
 - Hooks run with user credentials (same security model as settings.json)
 - Keep hook scripts fast (<30s timeout recommended)
 
+> **See also:** For complete matcher syntax including regex patterns and available tool names, see [Hook Events Reference — Matchers](../../references/hook-events.md#matchers).
+
 ## Agent Design Patterns
 
 Three proven patterns for building effective agents. Each pattern includes complete templates you can copy and customize.


### PR DESCRIPTION
## Summary

- Adds a "See also" callout in the agent-authoring SKILL.md hooks section linking to the full matcher syntax reference in `references/hook-events.md#matchers`

Closes #152

## Test plan

- [ ] Verify the relative link resolves correctly from `skills/agent-authoring/SKILL.md` to `references/hook-events.md#matchers`
- [ ] Confirm markdown passes `prettier` and `markdownlint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)