### PR TITLE
docs: add hooks example to Pattern 3 (Workflow Orchestrator)

### DIFF
--- a/skills/agent-authoring/design-patterns.md
+++ b/skills/agent-authoring/design-patterns.md
@@ -156,6 +156,32 @@ allowed_tools:
 - [Reporting methodology]
 ```
 
+**Optional: Add hooks for workflow management**:
+
+```yaml
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      command_pattern: "git tag *"
+      hooks:
+        - type: command
+          command: "./scripts/validate-tag-format.sh"
+          description: "Ensure tags follow semver"
+  PostToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/log-workflow-step.sh"
+          timeout: 5
+```
+
+> **Hooks in Orchestrators:** Workflow orchestrators benefit from hooks for:
+>
+> - Audit logging at each stage
+> - Validation gates before critical operations
+> - Notifications on completion or failure
+> - Metrics collection for process optimization
+
 ---
 
 ## Choosing a Pattern


### PR DESCRIPTION
## Summary

- Add optional hooks section to Pattern 3 (Workflow Orchestrator) in design-patterns.md
- Show PreToolUse for validation gates (git tag format checking) and PostToolUse for workflow logging
- Include explanatory blockquote on why orchestrators benefit from hooks

Closes #153

## Test plan

- [x] Verify markdown passes prettier and markdownlint
- [x] Confirm hooks example follows established patterns from Pattern 1 and 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)