### PR TITLE
chore: refactor hooks and relocate learned directory

### DIFF
--- a/hooks/evaluate-session.js
+++ b/hooks/evaluate-session.js
@@ -11,20 +11,18 @@
  * - UserPromptSubmit runs every message (heavy, adds latency)
  */
 
-const path = require("path");
-const fs = require("fs");
+const fs = require("node:fs");
 const {
   getLearnedSkillsDir,
   ensureDir,
-  readFile,
   countInFile,
   log,
 } = require("./lib/utils");
 
 async function main() {
   // Default configuration
-  let minSessionLength = 10;
-  let learnedSkillsPath = getLearnedSkillsDir();
+  const minSessionLength = 10;
+  const learnedSkillsPath = getLearnedSkillsDir();
 
   // Ensure learned skills directory exists
   ensureDir(learnedSkillsPath);

--- a/hooks/lib/utils.js
+++ b/hooks/lib/utils.js
@@ -3,10 +3,10 @@
  * Works on Windows, macOS, and Linux
  */
 
-const fs = require("fs");
-const path = require("path");
-const os = require("os");
-const { execSync, spawnSync } = require("child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+const { execSync, spawnSync } = require("node:child_process");
 
 // Platform detection
 const isWindows = process.platform === "win32";
@@ -38,7 +38,7 @@ function getSessionsDir() {
  * Get the learned skills directory
  */
 function getLearnedSkillsDir() {
-  return path.join(getClaudeDir(), "skills", "learned");
+  return path.join(getClaudeDir(), "learned");
 }
 
 /**
@@ -149,7 +149,7 @@ function findFiles(dir, pattern, options = {}) {
           searchDir(fullPath);
         }
       }
-    } catch (err) {
+    } catch {
       // Ignore permission errors
     }
   }

--- a/hooks/session-end.js
+++ b/hooks/session-end.js
@@ -8,15 +8,14 @@
  * with timestamp for continuity tracking.
  */
 
-const path = require("path");
-const fs = require("fs");
+const path = require("node:path");
+const fs = require("node:fs");
 const {
   getSessionsDir,
   getDateString,
   getTimeString,
   getSessionIdShort,
   ensureDir,
-  readFile,
   writeFile,
   replaceInFile,
   log,

--- a/hooks/session-start.js
+++ b/hooks/session-start.js
@@ -8,7 +8,6 @@
  * files and notifies Claude of available context to load.
  */
 
-const path = require("path");
 const {
   getSessionsDir,
   getLearnedSkillsDir,

--- a/learned/skill-structure-migration.md
+++ b/learned/skill-structure-migration.md
@@ -1,0 +1,44 @@
+# Skill Structure Migration Pattern
+
+**Extracted:** 2026-01-30
+**Context:** Fixing Claude Code skills that fail to trigger due to structural issues
+
+## Problem
+
+Skills may be undiscoverable when they:
+
+1. Have no YAML frontmatter (missing `name`, `description`)
+2. Are in wrong location (`skills/name.md` instead of `skills/name/SKILL.md`)
+3. Have trigger information buried in body instead of frontmatter description
+
+## Solution
+
+1. **Audit the skill** - Check for frontmatter, location, and description quality
+2. **Create proper directory** - `mkdir -p skills/{name}/`
+3. **Write SKILL.md with frontmatter**:
+
+   ```yaml
+   ---
+   name: skill-name
+   description: "What it does. When to use. Triggers on: phrase1, phrase2, phrase3."
+   allowed-tools: [Tool1, Tool2]
+   ---
+   ```
+
+4. **Move content** - Preserve body content, remove redundant trigger lines
+5. **Delete old file** - Remove `skills/{name}.md`
+6. **Validate** - Run prettier and markdownlint
+
+## Example
+
+```text
+# Before
+skills/learn.md  # No frontmatter, wrong location
+
+# After
+skills/learn/SKILL.md  # With frontmatter, correct location
+```
+
+## When to Use
+
+When a skill exists but doesn't appear in the available skills list, or when audit reveals structural issues with skill files.

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -41,7 +41,7 @@ Focus on these categories:
 2. **Identify Value** - Find the most valuable/reusable insight
 3. **Draft Skill** - Create skill file with clear problem/solution/example
 4. **Confirm** - Ask user to review before saving
-5. **Save** - Store to `~/.claude/skills/learn/[pattern-name].md`
+5. **Save** - Store to `~/.claude/learned/[pattern-name].md`
 
 ## Output Format
 


### PR DESCRIPTION
## Summary

- Use `node:` prefix for built-in module imports (Node.js best practice)
- Remove unused imports and variables
- Use `const` instead of `let` where values don't change  
- Move learned skills from `skills/learned/` to `learned/` (top-level)

## Changes

- `hooks/lib/utils.js` - Import refactor, path change for learned directory
- `hooks/evaluate-session.js` - Import cleanup, const usage
- `hooks/session-end.js` - Import cleanup
- `hooks/session-start.js` - Remove unused import
- `skills/learn/SKILL.md` - Update documentation path
- `learned/` - New location for extracted patterns

## Test plan

- [x] Hooks syntax validated
- [x] Path references updated consistently