### PR TITLE
feat: add /vc-sync command for repo cleanup

### DIFF
--- a/commands/vc-sync.md
+++ b/commands/vc-sync.md
@@ -1,0 +1,15 @@
+---
+description: Sync local repo - switch to main, update from remote, clean merged branches
+---
+
+Run the following commands to sync this repository:
+
+```bash
+git checkout main && gitup . && git sweep
+```
+
+This will:
+
+1. Switch to the main branch
+2. Update from remote (fetch + merge)
+3. Delete local branches that have been merged


### PR DESCRIPTION
## Summary

Adds `/vc-sync` command for quick repo cleanup after merging PRs.

## What it does

Runs: `git checkout main && gitup . && git sweep`

1. Switch to main branch
2. Update from remote (fetch + merge via gitup)
3. Delete local branches that have been merged (git sweep)

## Usage

```
/vc-sync
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)