### PR TITLE
feat: add hook event logging for debugging

### DIFF
--- a/hooks/log-hook-event.sh
+++ b/hooks/log-hook-event.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Hook event logging - logs hook events with timestamps
+# Note: Intentionally no 'set -euo pipefail' - hooks must always exit 0
+
+event_name="$1"
+timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+mkdir -p ~/.claude/logs
+
+input=$(cat)
+tool=""
+tool_input=""
+
+if [ -n "$input" ]; then
+	tool=$(echo "$input" | jq -r '.tool // .tool_name // empty' 2>/dev/null)
+	tool_input=$(echo "$input" | jq -c '.tool_input // empty' 2>/dev/null)
+fi
+
+line="[$timestamp] $event_name"
+if [ -n "$tool" ] && [ "$tool" != "null" ]; then
+	line="$line tool=$tool"
+fi
+if [ -n "$tool_input" ] && [ "$tool_input" != "null" ]; then
+	line="$line input=$tool_input"
+fi
+
+echo "$line" >>~/.claude/logs/hook-events.log
+
+exit 0

--- a/settings.json
+++ b/settings.json
@@ -12,6 +12,15 @@
           }
         ],
         "matcher": "idle_prompt"
+      },
+      {
+        "hooks": [
+          {
+            "command": "~/.claude/hooks/log-hook-event.sh Notification",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -24,6 +33,15 @@
           }
         ],
         "matcher": "Edit|Write"
+      },
+      {
+        "hooks": [
+          {
+            "command": "~/.claude/hooks/log-hook-event.sh PostToolUse",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
       }
     ],
     "PreToolUse": [
@@ -51,6 +69,26 @@
           }
         ],
         "matcher": "Edit|Write"
+      },
+      {
+        "hooks": [
+          {
+            "command": "~/.claude/hooks/log-hook-event.sh PreToolUse",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "command": "~/.claude/hooks/log-hook-event.sh PermissionRequest",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
       }
     ],
     "SessionStart": [
@@ -67,6 +105,15 @@
             "type": "command"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "~/.claude/hooks/log-hook-event.sh SessionStart",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
       }
     ],
     "Stop": [
@@ -78,6 +125,48 @@
           },
           {
             "command": "~/.claude/hooks/evaluate-session.js",
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "~/.claude/hooks/log-hook-event.sh Stop",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "command": "~/.claude/hooks/log-hook-event.sh SubagentStart",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "command": "~/.claude/hooks/log-hook-event.sh SubagentStop",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "~/.claude/hooks/log-hook-event.sh UserPromptSubmit",
+            "timeout": 5,
             "type": "command"
           }
         ]


### PR DESCRIPTION
Log all hook events to ~/.claude/logs/hook-events.log with timestamps, tool names, and inputs. Covers all event types: Notification, PreToolUse, PostToolUse, PermissionRequest, SessionStart, Stop, SubagentStart, SubagentStop, and UserPromptSubmit.