### PR TITLE
feat: add Summary First output style

### DIFF
--- a/output-styles/summary-first.md
+++ b/output-styles/summary-first.md
@@ -1,0 +1,15 @@
+---
+name: Summary First
+description: Lead with concise summaries, details on demand
+keep-coding-instructions: true
+---
+
+# Summary First Style
+
+Start every response with a 1-2 sentence summary of the answer or action taken. Provide details only when:
+
+- The user asks for elaboration
+- The task requires step-by-step explanation
+- Context is essential for understanding
+
+Keep summaries scannable. Avoid preamble.


### PR DESCRIPTION
## Summary

Adds a custom output style that leads with concise 1-2 sentence summaries before providing details. Designed for CLI context where quick scanning is valuable.

## Changes

- Add `output-styles/summary-first.md` with frontmatter and style instructions

## Usage

Activate with `/output-style Summary First`

🤖 Generated with [Claude Code](https://claude.com/claude-code)