### PR TITLE
feat: add personal-essay-editor skill

### DIFF
--- a/skills/personal-essay-editor/SKILL.md
+++ b/skills/personal-essay-editor/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: personal-essay-editor
+allowed-tools: [Read, Edit, Write]
+description: Copy editing skill for personal essays, memoirs, and first-person narratives. Use when editing, reviewing, rewriting, proofreading, tightening, cleaning up, or line editing personal writing where the author's voice must be preserved. Triggers include requests to edit, review, polish, copyedit, proofread, tighten, clean up, line edit, or rewrite essays while maintaining authenticity. Applies Orwell's clarity rules and Economist mechanics while prioritizing American first-person voice and the author's natural cadence. Also use when asked to flag issues, suggest fixes, or improve prose without changing meaning.
+---
+
+## Personal Essay Copy Editor
+
+### Voice Priority (in order)
+
+1. American first-person voice — the author's words, rhythm, and perspective
+2. Orwell's clarity rules — see <orwell.md>
+3. Economist mechanics — punctuation, word economy, jargon removal
+
+### Modes
+
+#### Edit Mode (default)
+
+Flag issues inline with [brackets] immediately after problematic text. Provide suggested fix after each flag. Preserve author's voice.
+
+```text
+Original: I was literally dying of embarrassment as I made my way through the doorway.
+Edited: I was literally [dead metaphor] dying of embarrassment [cut: implied] as I made my way [wordy] through the doorway [use: door].
+Fixes: "I was dying as I walked through the door." or "I flushed as I walked through the door."
+```
+
+#### Rewrite Mode
+
+When asked to rewrite, produce clean copy only. No markup, no explanations, no meta-commentary. Maintain:
+
+- First-person intimacy
+- Sentence variety and personal cadence
+- The author's meaning exactly
+- Sound like the author, not an editor
+
+### Orwell's Rules (Hard Constraints)
+
+1. Cut familiar metaphors and similes
+2. Short words over long
+3. Cut every cuttable word
+4. Active voice over passive
+5. Plain English over jargon and foreign phrases
+6. Break any rule to avoid barbarism
+
+For expanded guidance and examples: <orwell.md>
+
+### Quick Reference
+
+#### Always Cut
+
+- It is important to note
+- In order to (use: to)
+- The fact that
+- Basically, essentially, actually, literally
+- Very, really, quite, rather
+- I think that, I believe that (when attribution is obvious)
+- At the end of the day
+- First and foremost
+- Each and every
+
+#### Always Replace
+
+| Weak                      | Strong   |
+| ------------------------- | -------- |
+| utilize                   | use      |
+| in the event that         | if       |
+| at this point in time     | now      |
+| due to the fact that      | because  |
+| in spite of the fact that | although |
+| a large number of         | many     |
+| the majority of           | most     |
+| make a decision           | decide   |
+| give consideration to     | consider |
+| is able to                | can      |
+| in close proximity to     | near     |
+
+For complete word choice guidance: <word-choices.md>
+
+### Detecting Problems
+
+#### Passive Voice
+
+Flag when the actor is hidden or when active would be stronger. Keep passive when:
+
+- The actor is unknown or irrelevant
+- The receiver of action deserves emphasis
+- Passive creates better rhythm in context
+
+#### Nominalizations
+
+Weak verbs + abstract nouns → strong verbs:
+
+- made the decision → decided
+- came to the realization → realized
+- had a conversation → talked
+- gave an explanation → explained
+
+#### Prepositional Pile-ups
+
+Flag chains of three or more prepositions. Restructure to eliminate at least one.
+
+#### Clichés
+
+See <cliches.md> for the full list. When flagging, suggest a concrete replacement or recommend cutting entirely.
+
+### Punctuation
+
+For detailed guidance: <punctuation.md>
+
+Quick rules:
+
+- Serial comma: optional but consistent within piece
+- Dashes: sparingly, for emphasis or interruption
+- Semicolons: prefer periods in personal essays
+- Exclamation points: one per essay maximum; zero is better
+- Quotation marks: double for dialogue, single for quotes within quotes (American style)
+
+### American vs. British
+
+Use American spelling and idiom throughout. For specific differences: <american-british.md>
+
+Key American preferences:
+
+- Place adverbs after verbs, not before
+- Use American spelling (-ize, -or, -er)
+- American date format in examples (January 5, not 5 January)
+
+### Forbidden
+
+- Explanations of edits (unless asked)
+- Meta-commentary about the editing process
+- British spelling or usage
+- Softening direct statements
+- Adding qualifiers the author didn't use
+- Changing the author's meaning
+- Imposing a voice not their own
+- Suggesting the author "consider" something — either flag it or don't
+
+### Essay-Specific Guidance
+
+#### Openings
+
+Flag throat-clearing. The essay should begin with the story, not with setup. If the first paragraph could be cut without losing anything, flag it.
+
+#### Transitions
+
+Cut mechanical transitions (Additionally, Furthermore, Moreover, In conclusion). If the logic requires a transition, the paragraphs may be in the wrong order.
+
+#### Endings
+
+Flag summary endings that repeat what the essay already said. Flag morals stated explicitly when the essay already showed them. The best endings either land on a concrete image or stop the moment the point is made.
+
+### Output Format
+
+#### Edit Mode
+
+Return text with [bracketed flags] inline. After the flagged passage, provide suggested fixes. Group related fixes when efficient.
+
+#### Rewrite Mode
+
+Return clean copy only. No markup, no tracked changes, no commentary.
+
+#### When Asked to Explain
+
+Explain the specific edit requested. Do not explain the editing philosophy unless asked.
+
+### Reference Files
+
+Load these as needed:
+
+- <orwell.md> — Expanded Orwell rules with examples
+- <word-choices.md> — Commonly confused words, preferred usage
+- <punctuation.md> — American punctuation conventions
+- <cliches.md> — Comprehensive cliché list with fixes
+- <american-british.md> — Spelling, grammar, vocabulary differences
+- <examples.md> — Before/after editing examples for calibration

--- a/skills/personal-essay-editor/american-british.md
+++ b/skills/personal-essay-editor/american-british.md
@@ -1,0 +1,309 @@
+## American vs. British English
+
+This skill uses American English throughout. This reference covers key differences to watch for when editing.
+
+### Spelling
+
+#### -ize vs. -ise
+
+American: -ize
+
+- organize, recognize, realize, specialize, analyze
+
+British: -ise (often)
+
+- organise, recognise, realise, specialise, analyse
+
+#### -or vs. -our
+
+American: -or
+
+- color, honor, favor, neighbor, labor, humor
+
+British: -our
+
+- colour, honour, favour, neighbour, labour, humour
+
+#### -er vs. -re
+
+American: -er
+
+- center, theater, meter, fiber, somber
+
+British: -re
+
+- centre, theatre, metre, fibre, sombre
+
+#### -og vs. -ogue
+
+American: -og (often)
+
+- catalog, dialog, analog
+
+British: -ogue
+
+- catalogue, dialogue, analogue
+
+#### -ense vs. -ence
+
+American: -ense
+
+- defense, offense, license (noun and verb), pretense
+
+British: -ence (sometimes)
+
+- defence, offence, licence (noun), pretence
+
+#### -l vs. -ll
+
+American: single l before suffixes
+
+- traveled, traveling, traveler
+- canceled, canceling
+- leveled, leveling
+- modeled, modeling
+
+British: double ll
+
+- travelled, travelling, traveller
+- cancelled, cancelling
+- levelled, levelling
+- modelled, modelling
+
+#### Other Spelling Differences
+
+| American      | British        |
+| ------------- | -------------- |
+| airplane      | aeroplane      |
+| aluminum      | aluminium      |
+| artifact      | artefact       |
+| check (money) | cheque         |
+| curb          | kerb           |
+| donut         | doughnut       |
+| draft         | draught (beer) |
+| gray          | grey           |
+| jewelry       | jewellery      |
+| judgment      | judgement      |
+| maneuver      | manoeuvre      |
+| mold          | mould          |
+| mom           | mum            |
+| mustache      | moustache      |
+| pajamas       | pyjamas        |
+| plow          | plough         |
+| skeptic       | sceptic        |
+| tire          | tyre           |
+| toward        | towards        |
+
+### Grammar
+
+#### Collective Nouns
+
+American: usually singular
+
+- "The team is playing well."
+- "The government has decided."
+- "The company is expanding."
+
+British: often plural
+
+- "The team are playing well."
+- "The government have decided."
+- "The company are expanding."
+
+#### Past Tense Forms
+
+| American | British |
+| -------- | ------- |
+| learned  | learnt  |
+| dreamed  | dreamt  |
+| burned   | burnt   |
+| spelled  | spelt   |
+| spilled  | spilt   |
+| leaped   | leapt   |
+| kneeled  | knelt   |
+
+American accepts both forms but prefers -ed. Use -ed in this skill.
+
+#### Gotten vs. Got
+
+American: "gotten" as past participle
+
+- "I've gotten better at this."
+- "She's gotten used to it."
+
+British: "got" for both
+
+- "I've got better at this."
+
+Use "gotten" for American style.
+
+#### Shall vs. Will
+
+British: "shall" for first person future
+
+- "I shall go tomorrow."
+
+American: "will" for all persons
+
+- "I will go tomorrow."
+
+Use "will" unless "shall" serves a specific formal or emphatic purpose.
+
+#### Needn't, Shan't, Mustn't
+
+These contractions are common in British English, less so in American.
+
+American tends toward:
+
+- "don't need to" instead of "needn't"
+- "won't" instead of "shan't"
+- "must not" or "can't" instead of "mustn't"
+
+#### Have vs. Take
+
+British: "have a bath," "have a shower," "have a holiday"  
+American: "take a bath," "take a shower," "take a vacation"
+
+### Vocabulary
+
+| American             | British             |
+| -------------------- | ------------------- |
+| apartment            | flat                |
+| attorney/lawyer      | solicitor/barrister |
+| baby carriage        | pram                |
+| band-aid             | plaster             |
+| bathroom             | loo, toilet         |
+| bill (money)         | note                |
+| candy                | sweets              |
+| cell phone           | mobile              |
+| check (restaurant)   | bill                |
+| chips                | crisps              |
+| closet               | wardrobe, cupboard  |
+| cookie               | biscuit             |
+| corn                 | maize               |
+| cotton candy         | candyfloss          |
+| diaper               | nappy               |
+| drugstore            | chemist             |
+| elevator             | lift                |
+| eraser               | rubber              |
+| fall (season)        | autumn              |
+| faucet               | tap                 |
+| first floor          | ground floor        |
+| flashlight           | torch               |
+| french fries         | chips               |
+| garbage/trash        | rubbish             |
+| gas/gasoline         | petrol              |
+| highway/freeway      | motorway            |
+| hood (car)           | bonnet              |
+| intersection         | junction            |
+| jelly                | jam                 |
+| line (queue)         | queue               |
+| mail                 | post                |
+| napkin               | serviette           |
+| pants                | trousers            |
+| parking lot          | car park            |
+| period (punctuation) | full stop           |
+| pharmacy             | chemist             |
+| potato chips         | crisps              |
+| railroad             | railway             |
+| rent                 | hire                |
+| résumé               | CV                  |
+| round-trip           | return              |
+| rubber boots         | wellies             |
+| sidewalk             | pavement            |
+| sneakers             | trainers            |
+| soccer               | football            |
+| soda/pop             | fizzy drink         |
+| stove                | cooker              |
+| subway               | underground, tube   |
+| sweater              | jumper              |
+| trunk (car)          | boot                |
+| truck                | lorry               |
+| vacation             | holiday             |
+| vest                 | waistcoat           |
+| windshield           | windscreen          |
+| zee                  | zed                 |
+| zipper               | zip                 |
+
+### Punctuation
+
+#### Quotation Marks
+
+American: Double quotes primary, singles for nested
+
+- She said, "He called it 'magnificent.'"
+
+British: Often single quotes primary
+
+- She said, 'He called it "magnificent".'
+
+Use American double-quote style.
+
+#### Periods and Commas with Quotes
+
+American: Always inside quotation marks
+
+- She said, "Hello."
+- He called it "magnificent," but I disagreed.
+
+British: Logical placement (inside if part of quote)
+
+- She said, "Hello."
+- He called it "magnificent", but I disagreed.
+
+Use American style: periods and commas inside.
+
+#### Mr., Mrs., Dr
+
+American: with periods
+
+- Mr. Smith, Mrs. Jones, Dr. Brown
+
+British: without periods
+
+- Mr Smith, Mrs Jones, Dr Brown
+
+Use American style with periods.
+
+#### Dates
+
+American: Month Day, Year
+
+- January 5, 2024
+
+British: Day Month Year
+
+- 5 January 2024
+
+Use American date format.
+
+### Idioms and Expressions
+
+| American              | British                       |
+| --------------------- | ----------------------------- |
+| a whole new ball game | a completely different matter |
+| blow off steam        | let off steam                 |
+| Monday through Friday | Monday to Friday              |
+| on the weekend        | at the weekend                |
+| out in left field     | way off the mark              |
+| regular (coffee)      | white (coffee)                |
+| touch base            | get in touch                  |
+| visit with someone    | visit someone                 |
+
+### When to Preserve British English
+
+#### Direct Quotation
+
+If quoting a British source, preserve their spelling and usage within the quotation.
+
+#### British Subjects
+
+When writing about specifically British topics (the NHS, cricket, Parliament), some British terms may be clearer or more authentic.
+
+#### Established Names
+
+"Labour Party" (not "Labor Party"), "Centre Court" at Wimbledon, etc.
+
+#### Author's Choice
+
+If the author is British or writing for a British audience, discuss whether to maintain British usage throughout.

--- a/skills/personal-essay-editor/cliches.md
+++ b/skills/personal-essay-editor/cliches.md
@@ -1,0 +1,366 @@
+## Clichés
+
+Clichés are phrases so overused they've lost their impact. They signal lazy thinking—or worse, no thinking at all. Flag every cliché. Suggest cutting it entirely or replacing with concrete language.
+
+### The Test
+
+If you've heard it a hundred times, cut it.
+
+### Categories
+
+#### Dead Metaphors
+
+These once created images. Now they're invisible:
+
+- acid test
+- add insult to injury
+- at the end of the day
+- avoid like the plague
+- back to the drawing board
+- ballpark figure
+- beat around the bush
+- beat a dead horse
+- bent out of shape
+- between a rock and a hard place
+- bite the bullet
+- blessing in disguise
+- blood is thicker than water
+- bottom line
+- burn bridges
+- burning the midnight oil
+- calm before the storm
+- can of worms
+- chip on your shoulder
+- come full circle
+- compare apples and oranges
+- crystal clear
+- cut to the chase
+- devil's advocate
+- diamond in the rough
+- drop in the bucket
+- easier said than done
+- elephant in the room
+- face the music
+- fall through the cracks
+- few and far between
+- food for thought
+- get your feet wet
+- go the extra mile
+- greener pastures
+- have your cake and eat it too
+- hit the ground running
+- hit the nail on the head
+- in the heat of the moment
+- it takes two to tango
+- jump the gun
+- keep your chin up
+- last but not least
+- leave no stone unturned
+- level playing field
+- light at the end of the tunnel
+- low-hanging fruit
+- method to my madness
+- move the needle
+- needle in a haystack
+- no pain, no gain
+- on the same page
+- once in a blue moon
+- out of left field
+- par for the course
+- perfect storm
+- play it by ear
+- put all your eggs in one basket
+- read between the lines
+- right off the bat
+- roll with the punches
+- run it up the flagpole
+- see eye to eye
+- shoot from the hip
+- shot in the dark
+- silver lining
+- sleep on it
+- step up to the plate
+- take it with a grain of salt
+- the ball is in your court
+- the best of both worlds
+- the last straw
+- the tip of the iceberg
+- the whole nine yards
+- think outside the box
+- throw in the towel
+- throw under the bus
+- tip of the iceberg
+- turn over a new leaf
+- under the weather
+- up in the air
+- water under the bridge
+- when it rains it pours
+- win-win situation
+- worst-case scenario
+
+#### Business Clichés
+
+Corporate speak that infects personal writing:
+
+- actionable insights
+- at the end of the day
+- bandwidth
+- best practices
+- circle back
+- core competency
+- deep dive
+- deliverables
+- disrupt
+- drill down
+- ecosystem
+- empower
+- engage stakeholders
+- game-changer
+- going forward
+- granular
+- holistic
+- impactful
+- innovative
+- leverage
+- move the needle
+- on my radar
+- optimize
+- paradigm shift
+- pivot
+- proactive
+- push the envelope
+- reach out
+- robust
+- scalable
+- seamless
+- synergy
+- take it offline
+- takeaway
+- touch base
+- unpack
+- value-added
+- wheelhouse
+
+#### Emotional Clichés
+
+Feelings described without actually describing them:
+
+- a wave of emotion
+- blinding rage
+- brought tears to my eyes
+- butterflies in my stomach
+- chills ran down my spine
+- emotional roller coaster
+- felt like a weight had been lifted
+- filled with joy
+- flooded with memories
+- heart pounding
+- heart sank
+- heart skipped a beat
+- knot in my stomach
+- lost for words
+- my blood boiled
+- my blood ran cold
+- my heart melted
+- on cloud nine
+- shaking with anger
+- sick to my stomach
+- speechless
+- swept off my feet
+- time stood still
+- took my breath away
+- words cannot describe
+- words fail me
+
+#### Descriptive Clichés
+
+Lazy descriptions:
+
+- all shapes and sizes
+- as old as time
+- bated breath
+- beat of a different drummer
+- blazing sun
+- blind as a bat
+- bolt from the blue
+- bright-eyed and bushy-tailed
+- clear as day
+- cold as ice
+- cool as a cucumber
+- dark as night
+- dead of night
+- deafening silence
+- dry as a bone
+- dull as dishwater
+- fit as a fiddle
+- flat as a pancake
+- fresh as a daisy
+- gentle giant
+- good as gold
+- happy as a clam
+- hard as nails
+- light as a feather
+- nutty as a fruitcake
+- old as the hills
+- pale as a ghost
+- plain as day
+- pretty as a picture
+- pure as the driven snow
+- quick as a flash
+- quiet as a mouse
+- sharp as a tack
+- sick as a dog
+- sly as a fox
+- smooth as silk
+- snug as a bug
+- solid as a rock
+- strong as an ox
+- stubborn as a mule
+- sweet as honey
+- thin as a rail
+- tough as nails
+- ugly as sin
+- white as a sheet
+- wise as an owl
+
+#### Narrative Clichés
+
+Overused story moves:
+
+- a turning point
+- against all odds
+- all hell broke loose
+- and the rest is history
+- at a crossroads
+- changed my life
+- defining moment
+- everything happens for a reason
+- fate had other plans
+- hindsight is 20/20
+- I never looked back
+- if I knew then what I know now
+- in that moment
+- it was meant to be
+- it was the beginning of the end
+- it was the best of times
+- life as I knew it
+- life-changing
+- little did I know
+- looking back
+- moment of truth
+- my whole world changed
+- only time will tell
+- opened my eyes
+- point of no return
+- rude awakening
+- seize the day
+- silver lining
+- sobering realization
+- the beginning of a new chapter
+- the end of an era
+- the journey began
+- there are no words
+- things would never be the same
+- time heals all wounds
+- wake-up call
+- what doesn't kill you makes you stronger
+- when all was said and done
+- when push came to shove
+- who I am today
+
+#### Padding Clichés
+
+Phrases that add words without adding meaning:
+
+- a number of
+- all things considered
+- as a matter of fact
+- as far as I'm concerned
+- at the present time
+- at this point in time
+- basically
+- believe it or not
+- by and large
+- each and every
+- even as we speak
+- first and foremost
+- for all intents and purposes
+- for what it's worth
+- in a nutshell
+- in any case
+- in my opinion
+- in point of fact
+- in the final analysis
+- in the long run
+- in today's world
+- it goes without saying
+- last but not least
+- make a long story short
+- needless to say
+- not gonna lie
+- quite frankly
+- suffice it to say
+- that being said
+- the fact of the matter is
+- the thing is
+- to be honest
+- to tell you the truth
+- truth be told
+- when all is said and done
+- with all due respect
+
+### How to Fix Clichés
+
+#### Option 1: Cut Entirely
+
+Often the cliché adds nothing. Remove it and see if anything is lost.
+
+**Before:** "At the end of the day, I decided to leave."  
+**After:** "I decided to leave."
+
+#### Option 2: Be Concrete
+
+Replace the cliché with specific, observed detail.
+
+**Before:** "My blood ran cold."  
+**After:** "I stopped mid-step. My hands wouldn't move."
+
+**Before:** "It was a defining moment."  
+**After:** "Everything I did afterward traced back to that conversation."
+
+#### Option 3: Revive the Dead Metaphor
+
+If you must use a familiar image, make it fresh with specific detail.
+
+**Before:** "He was a bull in a china shop."  
+**After:** "He knocked over the display case reaching for a handshake."
+
+#### Option 4: Say It Plain
+
+Sometimes the simple statement is best.
+
+**Before:** "She threw me under the bus."  
+**After:** "She blamed me."
+
+**Before:** "We were on the same page."  
+**After:** "We agreed."
+
+### When Clichés Might Work
+
+#### In Dialogue
+
+People actually speak in clichés. Dialogue can reflect this authentically—but the narrative around it shouldn't.
+
+#### For Ironic Effect
+
+A cliché used with awareness, for humor or irony, can work. But the irony must be clear and earned.
+
+#### In Genre Conventions
+
+Some genres expect certain phrases. Know your genre, but also know that the best writing in any genre avoids cliché.
+
+### The Fix Test
+
+If you cut the cliché and the sentence means the same thing or nothing is lost, the cliché was padding. Leave it cut.
+
+If you cut the cliché and something is lost, find a concrete way to express what was lost. That concrete expression is better than the cliché.

--- a/skills/personal-essay-editor/examples.md
+++ b/skills/personal-essay-editor/examples.md
@@ -1,0 +1,212 @@
+## Editing Examples
+
+Before and after examples demonstrating the editing process. Study these to calibrate your edits.
+
+### Edit Mode Examples
+
+#### Example 1: Throat-Clearing Opening
+
+**Original:**
+
+> In today's fast-paced world, it is more important than ever to take time for self-reflection. I have often found myself thinking about the nature of happiness and what it means to live a fulfilling life. Recently, I came to the realization that I needed to make some changes.
+
+**Edited:**
+
+> In today's fast-paced world, [cliché] it is more important than ever [cut: empty emphasis] to take time for self-reflection. I have often found myself thinking about [wordy: "I've thought about"] the nature of happiness and what it means to live a fulfilling life [vague—what specifically?]. Recently, I came to the realization [nominalization: "I realized"] that I needed to make some changes [vague—what changes?].
+>
+> **Flags:** Opening paragraph is all setup, no story. Consider cutting entirely and starting with the specific changes or the moment of realization.
+
+**Rewritten:**
+
+> Last March, I quit my job.
+
+---
+
+#### Example 2: Passive Voice and Hidden Actor
+
+**Original:**
+
+> The decision was made to move forward with the project. It was determined that additional resources would be required. The team was informed of the changes.
+
+**Edited:**
+
+> The decision was made [passive: who decided?] to move forward with the project. It was determined [passive: who determined?] that additional resources would be required [passive]. The team was informed [passive—acceptable if actor is obvious] of the changes.
+>
+> **Note:** Three passives in a row. The first two hide the decision-maker, which may be evasion or may be intentional ambiguity. Clarify intent.
+
+**Rewritten (if the author decided):**
+
+> I decided to move forward. We'd need more resources. I told the team.
+
+**Rewritten (if someone else decided):**
+
+> My boss killed the budget review and approved the project. We'd need more resources. She told the team; I found out an hour later.
+
+---
+
+#### Example 3: Cliché Stacking
+
+**Original:**
+
+> At the end of the day, I had to think outside the box and push the envelope to move the needle. It was a game-changer.
+
+**Edited:**
+
+> At the end of the day, [cliché] I had to think outside the box [cliché] and push the envelope [cliché] to move the needle. [cliché] It was a game-changer. [cliché]
+>
+> **Note:** Five clichés in two sentences. No concrete information. What did you actually do?
+
+**Rewritten:**
+
+> I proposed something no one had tried: direct customer interviews instead of surveys. Response rates tripled.
+
+---
+
+#### Example 4: Nominalization and Weak Verbs
+
+**Original:**
+
+> My implementation of the new system led to an improvement in efficiency and a reduction in costs. The achievement of these goals resulted in recognition from management.
+
+**Edited:**
+
+> My implementation [nominalization: "I implemented" or "When I implemented"] of the new system led to an improvement [nominalization: "improved"] in efficiency and a reduction [nominalization: "reduced"] in costs. The achievement of these goals [nominalization: "Achieving these goals" or simply cut] resulted in [weak verb] recognition from management.
+
+**Rewritten:**
+
+> After I installed the new system, we worked faster and spent less. Management noticed.
+
+---
+
+#### Example 5: Prepositional Pile-up
+
+**Original:**
+
+> The report on the status of the implementation of the recommendations of the committee was distributed to the members of the board for review at the meeting on Tuesday.
+
+**Edited:**
+
+> The report on the status of the implementation of the recommendations of the committee [five prepositional phrases—restructure] was distributed [passive] to the members of the board for review at the meeting on Tuesday.
+
+**Rewritten:**
+
+> On Tuesday, the board reviewed how far we'd come on the committee's recommendations.
+
+---
+
+#### Example 6: Intensifiers and Hedging
+
+**Original:**
+
+> I was really very surprised and quite honestly somewhat overwhelmed by the incredibly positive response to what I thought was just a fairly simple suggestion.
+
+**Edited:**
+
+> I was really very [cut: stacked intensifiers] surprised and quite honestly somewhat [hedging—commit to the feeling or cut] overwhelmed by the incredibly positive [cut "incredibly"] response to what I thought was just a fairly simple [cut "fairly"] suggestion.
+
+**Rewritten:**
+
+> The response overwhelmed me. I'd thought the suggestion was simple.
+
+---
+
+#### Example 7: Emotional Telling, Not Showing
+
+**Original:**
+
+> I was absolutely devastated. My heart sank. I felt like my whole world had come crashing down around me. Words cannot describe how upset I was.
+
+**Edited:**
+
+> I was absolutely [cut] devastated. [vague—show it] My heart sank. [cliché] I felt like my whole world had come crashing down around me. [cliché] Words cannot describe [if words cannot describe, don't use words—show through action] how upset I was.
+>
+> **Note:** Four sentences telling emotion, zero showing it. What did you do? What did your body do?
+
+**Rewritten:**
+
+> I sat in the car for twenty minutes, keys in hand, unable to turn them.
+
+---
+
+#### Example 8: Mechanical Transitions
+
+**Original:**
+
+> Additionally, there are several other factors to consider. Furthermore, the economic implications cannot be ignored. Moreover, we must take into account the social impact. In conclusion, all of these elements point to the need for careful planning.
+
+**Edited:**
+
+> Additionally, [cut—if the logic requires a transition, the paragraphs may be in wrong order] there are several other factors to consider [vague—what factors?]. Furthermore, [cut] the economic implications cannot be ignored [passive evasion—who's ignoring them?]. Moreover, [cut] we must take into account [wordy: "we must consider"] the social impact. In conclusion, [cut—the conclusion should be self-evident] all of these elements point to the need for careful planning.
+>
+> **Note:** Transition words are doing no work. What are the factors, implications, and impacts?
+
+**Rewritten:**
+
+> The economics work, but the social cost might not. We need a careful plan.
+
+---
+
+#### Example 9: Summary Ending
+
+**Original:**
+
+> In summary, my trip to Japan taught me many valuable lessons about myself and about life. I learned the importance of stepping outside my comfort zone, trying new things, and being open to different cultures. This experience changed me in ways I never could have imagined, and I will carry these lessons with me for the rest of my life.
+
+**Edited:**
+
+> In summary, [cut—don't announce summaries] my trip to Japan taught me many valuable lessons [vague—what lessons?] about myself and about life. I learned the importance of [wordy: "I learned to"] stepping outside my comfort zone, [cliché] trying new things, [vague] and being open to different cultures. [vague] This experience changed me [cliché] in ways I never could have imagined, [cliché] and I will carry these lessons with me for the rest of my life. [cliché]
+>
+> **Note:** This paragraph says nothing specific. The essay should have already shown these lessons. If it did, cut this paragraph. If it didn't, the essay needs rewriting, not a summary.
+
+**Rewritten (option 1—concrete image):**
+
+> The last morning, I watched the sun rise over Fushimi Inari. A thousand vermilion gates stretched up the mountain. I walked through them alone.
+
+**Rewritten (option 2—cut entirely):**
+
+> [Delete the paragraph. End on the last concrete scene.]
+
+---
+
+#### Example 10: Good Writing Needing Light Touch
+
+**Original:**
+
+> My father built the cabin the year I was born. He worked weekends through the fall, driving up after his shift at the plant, coming home Sunday with sawdust still in his hair. I remember the smell of the wood—pine and something sharper, cedar maybe—mixed with the cigarette smoke that clung to his jacket. The cabin still stands. I haven't been back since his funeral.
+
+**Edited:**
+
+> [No flags needed. The prose is concrete, the sentences varied, the emotion shown through detail. Consider only: "something sharper, cedar maybe" could become "something sharper—cedar, maybe" or "cedar, maybe" for tighter rhythm.]
+
+**Note:** Good writing needs a light touch. Don't fix what isn't broken.
+
+---
+
+### Calibration Notes
+
+#### When to Flag vs. Silently Fix
+
+**Flag when:**
+
+- The fix requires judgment about author intent
+- Multiple valid fixes exist
+- The issue recurs and author should learn to spot it
+- The change affects meaning or voice
+
+**Fix silently when:**
+
+- The fix is mechanical and obvious
+- Only one correct option exists
+- The author requested a rewrite, not tracked edits
+
+#### Preserving Voice
+
+A nervous, hesitant narrator might legitimately use hedging language. A formal narrator might use longer words. The question is whether the choice serves the essay or results from habit.
+
+Ask: Is this word/phrase doing work for the essay, or is it just there?
+
+#### Sentence Variety
+
+Don't edit all sentences to the same length or structure. Varied rhythm serves prose. A short sentence after long ones creates emphasis. A long sentence can build momentum.
+
+The goal is clarity and impact, not uniformity.

--- a/skills/personal-essay-editor/orwell.md
+++ b/skills/personal-essay-editor/orwell.md
@@ -1,0 +1,270 @@
+## Orwell's Rules for Clear Writing
+
+George Orwell's six rules from "Politics and the English Language" (1946) form the foundation of this editing approach. Each rule includes examples showing before/after edits.
+
+### Rule 1: Never use a metaphor, simile, or figure of speech you are used to seeing in print
+
+Dead metaphors no longer evoke images. They fill space without adding meaning.
+
+#### Examples to Cut or Replace
+
+| Dead Metaphor          | Problem         | Fix                          |
+| ---------------------- | --------------- | ---------------------------- |
+| at the end of the day  | filler          | cut entirely, or: ultimately |
+| level playing field    | overused        | fair conditions              |
+| think outside the box  | cliché          | be creative, or cut          |
+| hit the ground running | dead image      | start immediately            |
+| move the needle        | business jargon | make a difference            |
+| low-hanging fruit      | overused        | easy wins, or cut            |
+| deep dive              | trendy cliché   | thorough look                |
+| circle back            | corporate speak | return to, revisit           |
+| paradigm shift         | academic bloat  | change                       |
+| synergy                | meaningless     | cut entirely                 |
+
+#### In Practice
+
+**Before:** At the end of the day, I had to think outside the box to level the playing field.
+
+**After:** I found an unconventional solution.
+
+**Before:** We did a deep dive into the data and found some low-hanging fruit.
+
+**After:** We examined the data and found easy improvements.
+
+#### When Metaphors Work
+
+Fresh metaphors that create vivid images are welcome. The test: does it make the reader see something new?
+
+**Weak:** Her anger was like a fire. (dead simile)
+
+**Strong:** Her anger crackled through the room, singeing everyone who got too close. (if this image serves the essay)
+
+**Stronger:** She was furious. (if the image doesn't serve the essay)
+
+### Rule 2: Never use a long word where a short one will do
+
+Short words are usually older, more direct, and more concrete. Long words often hide vague thinking.
+
+#### Common Substitutions
+
+| Long          | Short         |
+| ------------- | ------------- |
+| utilize       | use           |
+| implement     | do, start     |
+| facilitate    | help, ease    |
+| functionality | function, use |
+| methodology   | method        |
+| demonstrate   | show          |
+| terminate     | end           |
+| commence      | start, begin  |
+| endeavor      | try           |
+| subsequent    | next, later   |
+| prior to      | before        |
+| purchase      | buy           |
+| sufficient    | enough        |
+| approximately | about         |
+| regarding     | about         |
+| numerous      | many          |
+| additional    | more          |
+| currently     | now           |
+| indicate      | show, say     |
+| obtain        | get           |
+| provide       | give          |
+| require       | need          |
+| possess       | have          |
+| attempt       | try           |
+| inform        | tell          |
+
+#### In Practice
+
+**Before:** We will endeavor to utilize the new methodology to facilitate improved functionality.
+
+**After:** We will try the new method to make it work better.
+
+**Before:** Prior to the commencement of the subsequent phase, we require additional resources.
+
+**After:** Before the next phase starts, we need more resources.
+
+#### Exception
+
+Keep the longer word when it carries specific meaning the short word lacks. "Terminate" in a legal context may be more precise than "end." Match the word to its context.
+
+### Rule 3: If it is possible to cut a word, always cut it
+
+Every word must earn its place. If removing a word doesn't change the meaning, remove it.
+
+#### Words That Rarely Earn Their Place
+
+- very, really, quite, rather, somewhat
+- basically, essentially, actually, literally
+- just, simply, merely
+- in order to (use: to)
+- the fact that
+- that (often deletable after verbs of thinking/saying)
+- it is, there is, there are (often weak openers)
+
+#### Redundant Phrases
+
+| Redundant            | Concise             |
+| -------------------- | ------------------- |
+| past history         | history             |
+| future plans         | plans               |
+| end result           | result              |
+| final outcome        | outcome             |
+| completely finished  | finished            |
+| advance planning     | planning            |
+| basic fundamentals   | fundamentals        |
+| brief summary        | summary             |
+| close proximity      | proximity, or: near |
+| collaborate together | collaborate         |
+| consensus of opinion | consensus           |
+| each and every       | each, or: every     |
+| free gift            | gift                |
+| new innovation       | innovation          |
+| past experience      | experience          |
+| present time         | present, or: now    |
+| reason why           | reason              |
+| refer back           | refer               |
+| repeat again         | repeat              |
+| revert back          | revert              |
+| true fact            | fact                |
+| unexpected surprise  | surprise            |
+
+#### In Practice
+
+**Before:** The basic fundamentals of the plan were essentially quite simple in nature.
+
+**After:** The plan was simple.
+
+**Before:** I came to the realization that I would have to make a decision.
+
+**After:** I realized I had to decide.
+
+**Before:** It is important to note that there are many factors that need to be considered.
+
+**After:** Many factors matter. (Or cut entirely if the factors follow.)
+
+### Rule 4: Never use the passive where you can use the active
+
+Active voice: subject does the action. Passive voice: subject receives the action.
+
+Active is usually clearer, shorter, and more direct.
+
+#### Identifying Passive Voice
+
+Look for: [form of "to be"] + [past participle]
+
+- was broken
+- is being considered
+- has been decided
+- will be reviewed
+
+#### Converting Passive to Active
+
+| Passive                            | Active                      |
+| ---------------------------------- | --------------------------- |
+| The ball was thrown by me          | I threw the ball            |
+| Mistakes were made                 | We made mistakes            |
+| The decision was reached           | We decided                  |
+| It was determined that             | We determined               |
+| The report was written by the team | The team wrote the report   |
+| The issue is being addressed       | We are addressing the issue |
+
+#### When Passive Works
+
+Keep passive voice when:
+
+1. **The actor is unknown:** "My car was stolen." (You don't know who did it.)
+2. **The actor is irrelevant:** "The bridge was built in 1923." (Who built it doesn't matter for this sentence.)
+3. **The receiver deserves emphasis:** "The president was assassinated." (The president matters more than the assassin here.)
+4. **Passive creates better rhythm:** Sometimes sentence flow or paragraph structure benefits from passive. Trust your ear, but verify the passive is earning its place.
+
+#### In Practice
+
+**Before:** It was decided by the committee that the proposal would be rejected.
+
+**After:** The committee rejected the proposal.
+
+**Before:** The experience was one that would never be forgotten by me.
+
+**After:** I never forgot the experience.
+
+### Rule 5: Never use a foreign phrase, a scientific word, or a jargon word if you can think of an everyday English equivalent
+
+Plain English reaches more readers and communicates more directly.
+
+#### Foreign Phrases to Avoid
+
+| Foreign      | English                      |
+| ------------ | ---------------------------- |
+| ad hoc       | improvised, for this purpose |
+| bona fide    | genuine                      |
+| de facto     | in practice, actual          |
+| inter alia   | among other things           |
+| mea culpa    | my fault                     |
+| per se       | in itself, as such           |
+| quid pro quo | exchange, trade              |
+| status quo   | current situation            |
+| vice versa   | the reverse                  |
+| vis-à-vis    | regarding, compared with     |
+
+Exception: Some foreign phrases have no exact English equivalent or have become standard English (et cetera, etc.). Use judgment.
+
+#### Jargon to Avoid
+
+| Jargon          | Plain English               |
+| --------------- | --------------------------- |
+| actionable      | practical, usable           |
+| bandwidth       | capacity, time              |
+| deliverables    | results, work product       |
+| disambiguate    | clarify                     |
+| ecosystem       | system, environment         |
+| granular        | detailed                    |
+| holistic        | complete, whole             |
+| impactful       | effective, powerful         |
+| incentivize     | encourage, motivate         |
+| leverage (verb) | use                         |
+| learnings       | lessons                     |
+| onboard         | train, introduce            |
+| operationalize  | put into practice           |
+| optimize        | improve                     |
+| pivot           | change, shift               |
+| scalable        | expandable                  |
+| stakeholder     | participant, those involved |
+| synergize       | combine, work together      |
+| touchpoint      | contact, interaction        |
+| unpack          | explain, examine            |
+
+#### In Practice
+
+**Before:** We need to leverage our learnings to optimize the stakeholder experience.
+
+**After:** We should use what we learned to improve the experience.
+
+**Before:** The modus operandi of the organization vis-à-vis its competitors remains the status quo.
+
+**After:** The organization operates the same way it always has compared to its competitors.
+
+### Rule 6: Break any of these rules sooner than say anything outright barbarous
+
+The rules serve clarity. When following a rule makes the sentence worse, break the rule.
+
+#### When to Break Rules
+
+- A long word is more precise than its short alternative
+- A cliché is the clearest way to communicate an idea
+- Passive voice creates better rhythm or emphasis
+- A foreign phrase has no adequate English equivalent
+- Cutting a word removes necessary nuance
+
+#### The Test
+
+Read the sentence aloud. Does it sound natural? Does it communicate clearly? Would a thoughtful reader understand it immediately?
+
+If yes, the sentence works regardless of whether it follows every rule.
+
+If no, apply the rules more rigorously.
+
+#### The Ultimate Standard
+
+Orwell: "A scrupulous writer, in every sentence that he writes, will ask himself at least four questions: What am I trying to say? What words will express it? What image or idiom will make it clearer? Is this image fresh enough to have an effect? And he will probably ask himself two more: Could I put it more shortly? Have I said anything that is avoidably ugly?"

--- a/skills/personal-essay-editor/punctuation.md
+++ b/skills/personal-essay-editor/punctuation.md
@@ -1,0 +1,327 @@
+## Punctuation
+
+This reference covers punctuation decisions for personal essays, using American conventions.
+
+### Commas
+
+#### Serial Comma (Oxford Comma)
+
+Optional, but be consistent throughout the piece.
+
+With serial comma: "I bought apples, oranges, and bananas."  
+Without: "I bought apples, oranges and bananas."
+
+Use the serial comma when it prevents ambiguity:
+
+- Ambiguous: "I love my parents, Batman and Wonder Woman."
+- Clear: "I love my parents, Batman, and Wonder Woman."
+
+#### Comma Splices
+
+Two independent clauses joined by only a comma is a comma splice. Usually wrong in formal prose.
+
+**Comma splice:** "I went to the store, I bought milk."
+
+**Fixes:**
+
+- Period: "I went to the store. I bought milk."
+- Semicolon: "I went to the store; I bought milk."
+- Conjunction: "I went to the store, and I bought milk."
+- Subordination: "When I went to the store, I bought milk."
+
+**Exception:** Short, parallel clauses can work as comma splices for rhythm.
+
+- "I came, I saw, I conquered."
+- "The door opened, she walked in."
+
+Use this deliberately and sparingly.
+
+#### Commas with Introductory Elements
+
+Use a comma after introductory phrases of three or more words:
+
+- "After the long drive, I needed rest."
+- "In the morning, we left."
+
+Short introductory phrases may omit the comma if clear:
+
+- "In 1984 Orwell's vision seemed prescient." (clear without comma)
+- "In 1984, the city changed." (comma needed to prevent misreading)
+
+Always use a comma after introductory dependent clauses:
+
+- "When I arrived, the party had ended."
+
+#### Commas with Nonrestrictive Elements
+
+Use commas around nonessential (nonrestrictive) information:
+
+- "My brother, who lives in Boston, visited last week." (I have one brother)
+- "My brother who lives in Boston visited last week." (I have multiple brothers; this identifies which one)
+
+#### Commas Before Conjunctions
+
+Use a comma before a coordinating conjunction (and, but, or, nor, for, so, yet) joining two independent clauses:
+
+- "I wanted to stay, but I had to leave."
+
+No comma needed if the second clause isn't independent:
+
+- "I wanted to stay but had to leave." (no subject in second clause)
+
+### Semicolons
+
+#### Joining Independent Clauses
+
+Use semicolons to join closely related independent clauses without a conjunction:
+
+- "The project failed; no one was surprised."
+
+The clauses should be genuinely related. If you'd use "however" or "therefore," a semicolon often works.
+
+#### In Personal Essays
+
+Semicolons can feel formal. Consider whether two sentences would serve better:
+
+- Formal: "She never explained; I never asked."
+- Personal: "She never explained. I never asked."
+
+Both work. Match the tone of the essay.
+
+#### With Items Containing Commas
+
+Use semicolons to separate list items that contain commas:
+
+- "I visited Paris, France; London, England; and Rome, Italy."
+
+### Colons
+
+#### Introducing Lists
+
+Use a colon after a complete sentence that introduces a list:
+
+- "I need three things: time, money, and luck."
+
+Don't use a colon if the list completes an incomplete sentence:
+
+- Incorrect: "I need: time, money, and luck."
+- Correct: "I need time, money, and luck."
+
+#### Introducing Explanations
+
+Use a colon to introduce an explanation, amplification, or example:
+
+- "She had one rule: never apologize."
+- "The reason was simple: money."
+
+#### After Colons
+
+In American English, capitalize the first word after a colon if it begins a complete sentence:
+
+- "The verdict was clear: He was guilty."
+- "She wanted one thing: peace."
+
+### Dashes
+
+#### Em Dashes (—)
+
+Use em dashes for:
+
+**Interruption or break in thought:**
+
+- "I was going to explain—but what's the point?"
+
+**Emphasis or amplification:**
+
+- "She had one quality—persistence—that set her apart."
+
+**Introducing a list after a fragment:**
+
+- "All of it—the noise, the crowds, the heat—exhausted me."
+
+#### Usage Notes
+
+- No spaces around em dashes in American style
+- Use sparingly; more than two per paragraph dilutes their effect
+- Parentheses de-emphasize; dashes emphasize
+
+#### En Dashes (–)
+
+Use en dashes for:
+
+- Ranges: "pages 10–15," "1990–2000"
+- Compound adjectives with multi-word elements: "New York–based," "post–Civil War"
+
+In personal essays, hyphens often substitute for en dashes in ranges. Be consistent.
+
+### Hyphens
+
+#### Compound Adjectives Before Nouns
+
+Hyphenate compound modifiers before nouns:
+
+- "A well-known author"
+- "A full-time job"
+- "A two-year-old child"
+
+Don't hyphenate after the noun:
+
+- "The author is well known."
+- "The job is full time."
+
+#### Don't Hyphenate
+
+- Adverb + adjective combinations where the adverb ends in -ly:
+  - "A newly discovered species" (not "newly-discovered")
+  - "A highly regarded expert"
+- Compound modifiers that are so common they're clear:
+  - "high school student" (not "high-school student")
+
+#### Prefixes
+
+Generally don't hyphenate prefixes:
+
+- "Nonprofit," "coworker," "prewar," "reevaluate"
+
+Hyphenate to avoid confusion or awkward letter combinations:
+
+- "Re-sign" (sign again) vs. "resign" (quit)
+- "Co-op" (not "coop")
+- "Pre-eminent" or "preeminent" (both acceptable)
+
+Hyphenate before proper nouns or numbers:
+
+- "Pre-1990," "anti-American"
+
+### Apostrophes
+
+#### Possessives
+
+**Singular nouns:** Add 's
+
+- "The dog's collar"
+- "James's book" (or "James' book"—be consistent)
+
+**Plural nouns ending in s:** Add only an apostrophe
+
+- "The dogs' collars"
+- "The Smiths' house"
+
+**Plural nouns not ending in s:** Add 's
+
+- "The children's toys"
+- "The women's room"
+
+#### Contractions
+
+Apostrophes mark omitted letters:
+
+- "Don't" (do not)
+- "It's" (it is or it has)
+- "You're" (you are)
+
+#### Its vs. It's
+
+- "Its" = possessive (no apostrophe): "The dog wagged its tail."
+- "It's" = contraction of "it is" or "it has": "It's raining."
+
+#### No Apostrophes in Plurals
+
+- Incorrect: "The 1990's," "DVD's"
+- Correct: "The 1990s," "DVDs"
+
+Exception: Lowercase letters may take apostrophes for clarity:
+
+- "Mind your p's and q's."
+
+### Quotation Marks
+
+#### American Style
+
+- Double quotation marks for direct speech and quotations
+- Single quotation marks for quotes within quotes
+- Periods and commas go inside quotation marks
+- Colons and semicolons go outside
+- Question marks and exclamation points go inside if part of the quote, outside if not
+
+**Examples:**
+
+- She said, "I'll be there."
+- "I'll be there," she said.
+- Did she say, "I'll be there"?
+- She asked, "Will you be there?"
+- He called it "magnificent"; I disagreed.
+
+#### Scare Quotes
+
+Use quotation marks around words used ironically or with skepticism:
+
+- "The 'solution' only made things worse."
+
+Use sparingly. Overuse suggests you don't trust your prose to convey tone.
+
+#### Titles
+
+Use quotation marks for:
+
+- Article titles
+- Chapter titles
+- Short story titles
+- Poem titles
+- Song titles
+- Episode titles
+
+Use italics for:
+
+- Book titles
+- Magazine/newspaper titles
+- Album titles
+- Film titles
+- TV series titles
+
+### Ellipses
+
+#### Omissions in Quotations
+
+Use three dots with spaces around them to indicate omitted text:
+
+- Original: "I went to the store and bought milk and bread."
+- With ellipsis: "I went to the store … and bought … bread."
+
+#### For Trailing Off
+
+In personal essays, ellipses can indicate trailing thoughts:
+
+- "I wanted to explain, but…"
+
+Use sparingly. Often a dash or period works better.
+
+#### Don't Use For
+
+- General emphasis or drama
+- Making every pause feel significant
+- Avoiding commitment to a statement
+
+### Exclamation Points
+
+#### In Personal Essays
+
+One per essay is plenty. Zero is often better.
+
+Exclamation points tell the reader how to feel. Strong prose creates the feeling without instruction.
+
+**Weak:** "I couldn't believe it!"  
+**Stronger:** "I couldn't believe it."  
+**Strongest:** Show disbelief through action or observation.
+
+#### When They Work
+
+- Direct dialogue where the character is actually shouting
+- Genuine exclamations: "Fire!" "Help!"
+- Ironic understatement (rare)
+
+#### Never
+
+- Multiple exclamation points: "I was so excited!!!"
+- Combined with question marks: "What?!"
+- For emphasis that the prose should provide

--- a/skills/personal-essay-editor/word-choices.md
+++ b/skills/personal-essay-editor/word-choices.md
@@ -1,0 +1,351 @@
+## Word Choices
+
+Precise words matter. This reference covers commonly confused words, preferred usage, and words to avoid.
+
+### Commonly Confused Words
+
+#### A
+
+**affect / effect**
+
+- Affect (verb): to influence. "The weather affected her mood."
+- Effect (noun): result. "The effect was immediate."
+- Effect (verb): to bring about. "She effected a change." (Rare; prefer "brought about")
+
+**aggravate**
+
+- Means: make worse
+- Does not mean: irritate or annoy
+- Correct: "The treatment aggravated his condition."
+- Incorrect: "Her delay aggravated me."
+
+**alibi**
+
+- Means: the fact of being elsewhere
+- Does not mean: an excuse or explanation
+- Correct: "His alibi placed him in Chicago."
+- Incorrect: "She had no alibi for being late."
+
+**alternate / alternative**
+
+- Alternate (adj): every other. "We meet on alternate Tuesdays."
+- Alternative (noun): one of two choices. "The alternative is worse."
+- Alternative (adj): available as another choice
+
+**among / between**
+
+- Traditional rule: between for two, among for more than two
+- This distinction is unnecessary in modern usage
+- Both work: "divided between three parties" or "divided among three parties"
+- Prefer "among" to "amongst"
+
+**anticipate**
+
+- Means: to forestall, to act in advance of, or to look forward to
+- Does not mean: expect
+- Correct: "She anticipated his objection and addressed it first."
+- Weak: "I anticipate he will arrive at noon." (Use "expect")
+
+**appraise / apprise**
+
+- Appraise: to set a price on, evaluate
+- Apprise: to inform
+- "She appraised the jewelry." / "He apprised me of the situation."
+
+**avert / avoid / evade**
+
+- Avert: to head off, prevent
+- Avoid: to keep away from
+- Evade: to elude, escape artfully
+- "Tax avoidance is legal; tax evasion is not."
+
+#### B-C
+
+**beg the question**
+
+- Means: to assume the conclusion in your premise (circular reasoning)
+- Does not mean: to raise the question
+- Correct: "Saying the law is right because it's the law begs the question."
+- For "raises the question," just say "raises the question"
+
+**compose / comprise**
+
+- The whole comprises the parts
+- The parts compose the whole
+- Correct: "The team comprises five members."
+- Correct: "Five members compose the team."
+- Never: "comprised of"
+
+**continual / continuous**
+
+- Continual: repeated with intervals. "Continual interruptions"
+- Continuous: unbroken. "Continuous noise"
+
+#### D-E
+
+**decimate**
+
+- Originally: to kill one in ten
+- Now acceptable: to destroy a large portion
+- Avoid: "completely decimated" (redundant or contradictory)
+
+**disinterested / uninterested**
+
+- Disinterested: impartial, having no stake
+- Uninterested: not interested, bored
+- "A judge should be disinterested but not uninterested."
+
+**economic / economical**
+
+- Economic: relating to the economy
+- Economical: thrifty, efficient
+- "Economic policy" / "An economical car"
+
+#### F-I
+
+**flaunt / flout**
+
+- Flaunt: to display ostentatiously
+- Flout: to treat with contempt, violate
+- "She flaunted her wealth." / "He flouted the rules."
+
+**forgo / forego**
+
+- Forgo: to do without
+- Forego: to go before (rare; "foregone conclusion")
+
+**historic / historical**
+
+- Historic: important in history
+- Historical: relating to history
+- "A historic moment" / "Historical records"
+
+**imply / infer**
+
+- Imply: to suggest (speaker/writer does this)
+- Infer: to deduce (listener/reader does this)
+- "She implied she was unhappy." / "I inferred from her tone that she was unhappy."
+
+#### L-P
+
+**lay / lie**
+
+- Lay: to put down (takes an object). Past: laid
+- Lie: to recline (no object). Past: lay
+- "Lay the book on the table." / "I need to lie down."
+- "She laid the papers aside." / "He lay on the couch."
+
+**literally**
+
+- Means: actually, without exaggeration
+- Frequently misused for emphasis
+- Incorrect: "I literally died of embarrassment."
+- Correct: "The building literally collapsed."
+
+**militate / mitigate**
+
+- Militate: to work against. "Facts militate against that conclusion."
+- Mitigate: to lessen. "Nothing can mitigate the damage."
+
+**practicable / practical**
+
+- Practicable: capable of being done
+- Practical: useful, sensible
+- "The plan is practicable but not practical."
+
+**presently**
+
+- Traditional meaning: soon
+- Increasingly used to mean: now
+- Prefer "soon" or "now" to avoid ambiguity
+
+**principal / principle**
+
+- Principal (noun): chief person, capital sum
+- Principal (adj): main, chief
+- Principle (noun): fundamental truth, rule
+
+#### R-W
+
+**refute**
+
+- Means: to prove false
+- Does not mean: to deny or dispute
+- Correct: "The evidence refuted his claim."
+- Incorrect: "She refuted the allegation." (unless she proved it false)
+
+**simplistic**
+
+- Means: oversimplified, naively simple
+- Does not mean: simple
+- "Simplistic" is pejorative; "simple" is often praise
+
+**that / which**
+
+- That: for restrictive clauses (essential to meaning)
+- Which: for non-restrictive clauses (additional info)
+- "The car that I bought is red." (identifies which car)
+- "The car, which I bought last year, is red." (adds info about the only car mentioned)
+
+**tortuous / torturous**
+
+- Tortuous: winding, complex
+- Torturous: causing torture
+- "A tortuous path" / "A torturous experience"
+
+### Prefer the Shorter Word
+
+| Avoid          | Prefer           |
+| -------------- | ---------------- |
+| accommodate    | hold, fit        |
+| accompany      | go with          |
+| accomplish     | do               |
+| accumulate     | gather, build up |
+| additional     | more             |
+| advantageous   | helpful          |
+| approximately  | about            |
+| assistance     | help             |
+| cognizant      | aware            |
+| commence       | begin, start     |
+| concerning     | about            |
+| consequently   | so               |
+| demonstrate    | show             |
+| discontinue    | stop             |
+| endeavor       | try              |
+| enumerate      | list             |
+| equivalent     | equal            |
+| exclusively    | only             |
+| expedite       | speed up         |
+| finalize       | finish, complete |
+| frequently     | often            |
+| implement      | do, carry out    |
+| indicate       | show, say        |
+| initiate       | start, begin     |
+| locate         | find             |
+| magnitude      | size             |
+| modification   | change           |
+| necessity      | need             |
+| numerous       | many             |
+| obtain         | get              |
+| participate    | take part        |
+| percentage     | part             |
+| permit         | let              |
+| portion        | part             |
+| possess        | have             |
+| prioritize     | rank             |
+| procure        | get              |
+| proficiency    | skill            |
+| provide        | give             |
+| purchase       | buy              |
+| regarding      | about            |
+| reimburse      | pay back         |
+| remainder      | rest             |
+| remuneration   | pay              |
+| requirement    | need             |
+| reside         | live             |
+| retain         | keep             |
+| specifications | details          |
+| subsequent     | next, later      |
+| sufficient     | enough           |
+| terminate      | end              |
+| transmit       | send             |
+| utilize        | use              |
+
+### Words to Avoid
+
+#### Empty Intensifiers
+
+Cut these unless they add specific meaning:
+
+- very
+- really
+- quite
+- rather
+- somewhat
+- fairly
+- extremely
+- incredibly
+- absolutely
+- totally
+- completely
+
+#### Filler Phrases
+
+| Filler                       | Replacement          |
+| ---------------------------- | -------------------- |
+| at this point in time        | now                  |
+| at the present time          | now                  |
+| in the event that            | if                   |
+| in the process of            | (cut; use verb)      |
+| in terms of                  | (rephrase)           |
+| it is important to note that | (cut; just state it) |
+| the fact that                | (rephrase or cut)    |
+| in order to                  | to                   |
+| for the purpose of           | to, for              |
+| with regard to               | about                |
+| with respect to              | about                |
+| on the basis of              | based on, because    |
+| in spite of the fact that    | although             |
+| due to the fact that         | because              |
+| by means of                  | by, with             |
+| in a manner that             | (rephrase)           |
+| has the ability to           | can                  |
+| is able to                   | can                  |
+| has the capacity to          | can                  |
+| in light of                  | because, given       |
+| in view of                   | because, given       |
+
+#### Meaningless Qualifiers
+
+Cut these when they add nothing:
+
+- basically
+- essentially
+- actually
+- literally (when not literal)
+- virtually
+- practically
+- effectively (when meaning "in effect")
+- relatively
+- generally
+- typically
+- usually
+- often (when vague)
+- sometimes (when vague)
+
+### Business and Academic Jargon
+
+Replace these with plain English:
+
+| Jargon           | Plain English          |
+| ---------------- | ---------------------- |
+| action (verb)    | act on, do             |
+| bandwidth        | time, capacity         |
+| best practice    | good method            |
+| bottom line      | result, conclusion     |
+| core competency  | strength, skill        |
+| deliverables     | results, products      |
+| drill down       | examine, analyze       |
+| empower          | allow, let             |
+| end-user         | user                   |
+| functionality    | function, features     |
+| going forward    | from now on, in future |
+| holistic         | complete, whole        |
+| impact (verb)    | affect                 |
+| incentivize      | encourage              |
+| interface (verb) | meet, talk             |
+| leverage (verb)  | use                    |
+| liaise           | work with, coordinate  |
+| mindset          | attitude               |
+| operationalize   | put into practice, do  |
+| optimize         | improve                |
+| paradigm         | model, example         |
+| parameters       | limits                 |
+| proactive        | active                 |
+| reach out        | contact                |
+| robust           | strong                 |
+| scalable         | expandable             |
+| stakeholder      | those involved         |
+| synergy          | combined effect        |
+| utilize          | use                    |
+| value-added      | valuable, useful       |


### PR DESCRIPTION
## Summary

- Add personal-essay-editor skill for copy editing personal essays, memoirs, and first-person narratives
- SKILL.md (176 lines) with 6 reference files covering Orwell's rules, clichés, punctuation, word choices, American/British conventions, and editing examples
- Fixes directory name typo (`presonal` → `personal`), adds `allowed-tools`, expands trigger phrases

## Test plan

- [x] Verify skill appears in Claude Code skill list
- [x] Test edit mode with a sample personal essay passage
- [x] Test rewrite mode produces clean copy without markup
- [x] Verify reference files load when contextually linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)