### PR TITLE
docs: expand project CLAUDE.md with architecture and workflow guidance

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,3 +1,84 @@
+# claude-code-setup
+
+Claude Code customization repository: skills, agents, hooks, rules, commands, references, and output styles.
+
+## Architecture
+
+Components live under `.claude/` in a flat layout:
+
+| Type           | Location                    | Trigger          |
+| -------------- | --------------------------- | ---------------- |
+| Skills         | `skills/<name>/SKILL.md`    | Auto-detected    |
+| Agents         | `agents/<name>.md`          | Auto or explicit |
+| Commands       | `commands/<name>.md`        | `/command`       |
+| Hooks          | `hooks/<name>.sh\|.py\|.js` | Lifecycle events |
+| Rules          | `rules/<name>.md`           | Path-matched     |
+| References     | `references/<name>.md`      | Loaded by skills |
+| Output Styles  | `output-styles/<name>.md`   | Session-level    |
+
+See `references/decision-matrix.md` for when to use each component type.
+
+## Conventions
+
+### Skills
+
+- One directory per skill: `skills/<name>/SKILL.md` plus flat reference files
+- SKILL.md target: under 200 lines; use reference files for depth (progressive disclosure)
+- Required frontmatter: `name`, `description` (with trigger phrases)
+- Optional frontmatter: `allowed-tools`
+- Name must be kebab-case, match the directory name, max 64 chars
+- Description should include **what** it does and **when** to use it (200-500 chars)
+
+### Hooks
+
+- Configured in `settings.json`, not in frontmatter
+- Exit codes: 0 = allow, 2 = block
+- The `auto-format.sh` PostToolUse hook runs prettier on Edit/Write automatically
+- The `validate-config.py` PreToolUse hook validates frontmatter on Edit/Write
+
+### Naming
+
+- All component names: kebab-case, lowercase, hyphens only
+- See `references/naming-conventions.md` for full patterns
+- See `references/frontmatter-requirements.md` for YAML specs
+
+## Formatting and Linting
+
+- **Markdown/YAML**: Prettier (`bunx prettier --write <file>`)
+- **TS/JS/JSON**: Biome (`bunx biome check --fix`)
+- **Python**: Ruff
+- **Code blocks**: Must have a language tag (e.g., `bash`, `ts`, `json`, `text`)
+- The auto-format hook handles Prettier on every Edit/Write — manual runs needed only for batch formatting
+
+## Common Commands
+
+### Quality workflow
+
+- `/cc-lint` — Quick structural validation (YAML, required fields, naming)
+- `/skill-quality` — Score skills across 6 quality dimensions (1-5)
+- `/skill-improve` — Generate prioritized improvement recommendations
+
+### Shipping and syncing
+
+- `/vc-ship` — Branch management, atomic commits, history cleanup, PR creation
+- `/vc-sync` — Switch to main, pull remote, clean merged branches
+
+### Manual formatting
+
+```bash
+bunx prettier --write <file>
+bunx prettier --check .
+bunx biome check --fix
+```
+
+## Git Workflow
+
+- Branch names: `feat/<name>`, `fix/<name>`, `docs/<name>`
+- One atomic commit per logical change
+- Use `/vc-ship` for the full 7-phase ship process (branch, commit, cleanup, PR)
+
+## Evaluation-Driven Workflow
+
 When implementing fixes from evaluation reports, always verify each fix individually before moving to the next one. After all fixes are applied, run the full quality evaluation to confirm everything passes.
 
 After completing any skill-related changes (directory renames, frontmatter updates, allowed-tools modifications), automatically run the /skill-quality evaluation to validate the changes.


### PR DESCRIPTION
## Summary

- Rewrites `.claude/CLAUDE.md` from 5 lines to 87 lines of project-specific guidance
- Adds architecture table mapping all component types to their locations and triggers
- Documents conventions (skills, hooks, naming), formatting/linting tools, common commands, and git workflow
- Preserves original evaluation-driven workflow instructions

## Test plan

- [x] `bunx prettier --check .claude/CLAUDE.md` passes
- [x] No duplication with global CLAUDE.md (principles, code prefs, environment)
- [x] All referenced paths and commands verified against actual repo contents
- [ ] Start a new session and confirm CLAUDE.md loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)