### PR TITLE
feat: add simplified statusline without Pro usage tracking

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "cleanupPeriodDays": 7,
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh"
+  },
   "hooks": {
     "Notification": [
       {

--- a/statusline.sh
+++ b/statusline.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Claude Code statusline — reads JSON from stdin, outputs colored single-line status
+set -euo pipefail
+
+# Colors (ANSI)
+CYAN='\033[36m'
+BLUE='\033[34m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+RED='\033[31m'
+MAGENTA='\033[35m'
+RESET='\033[0m'
+SEP=" │ "
+
+# Read JSON from stdin
+INPUT=$(cat)
+
+# Extract fields via jq
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+MODEL=$(echo "$INPUT" | jq -r '.model // empty')
+CONTEXT_USED=$(echo "$INPUT" | jq -r '.context.used // 0')
+CONTEXT_TOTAL=$(echo "$INPUT" | jq -r '.context.total // 1')
+OUTPUT_STYLE=$(echo "$INPUT" | jq -r 'if .output_style | type == "object" then .output_style.name else .output_style end // "default"')
+
+# Shorten home directory
+SHORT_CWD="${CWD/#$HOME/~}"
+
+# Model display name
+case "$MODEL" in
+  *opus*) MODEL_NAME="Opus" ;;
+  *sonnet*) MODEL_NAME="Sonnet" ;;
+  *haiku*) MODEL_NAME="Haiku" ;;
+  *) MODEL_NAME="${MODEL:-unknown}" ;;
+esac
+
+# Context remaining percentage
+if [ "$CONTEXT_TOTAL" -gt 0 ] 2>/dev/null; then
+  CTX_REMAINING=$(( (CONTEXT_TOTAL - CONTEXT_USED) * 100 / CONTEXT_TOTAL ))
+else
+  CTX_REMAINING=100
+fi
+
+if [ "$CTX_REMAINING" -gt 50 ]; then
+  CTX_COLOR="$GREEN"
+elif [ "$CTX_REMAINING" -ge 20 ]; then
+  CTX_COLOR="$YELLOW"
+else
+  CTX_COLOR="$RED"
+fi
+
+# Output style segment (hidden when "default")
+STYLE_SEGMENT=""
+if [ -n "$OUTPUT_STYLE" ] && [ "$OUTPUT_STYLE" != "default" ]; then
+  STYLE_SEGMENT="${SEP}${MAGENTA}${OUTPUT_STYLE}${RESET}"
+fi
+
+# Compose status line
+printf "%b%s%b%s%b%s%b%s%bctx:%d%%%b%b" \
+  "$CYAN" "$SHORT_CWD" "$RESET" \
+  "$SEP" \
+  "$BLUE" "$MODEL_NAME" "$RESET" \
+  "$SEP" \
+  "$CTX_COLOR" "$CTX_REMAINING" "$RESET" \
+  "$STYLE_SEGMENT"


### PR DESCRIPTION
## Summary

- Remove broken OAuth/caching Pro usage subsystem that failed silently (token lookup never worked)
- Re-add simplified statusline showing: cwd, model, context remaining, output style
- Claude Code already warns natively above 90% usage with reset time — no need for custom tracking

## Test plan

- [x] Verify statusline renders correctly: `echo '{"cwd":"/Users/markayers/.claude","model":"claude-opus-4-6","context":{"used":30000,"total":200000},"output_style":{"name":"Summary First"}}' | ~/.claude/statusline.sh | cat -v`
- [x] Confirm all 4 segments display with correct ANSI colors
- [x] Verify low-context warning (RED) triggers when remaining < 20%

🤖 Generated with [Claude Code](https://claude.com/claude-code)