### PR TITLE
fix: remove markdownlint references and config

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,0 @@
-{
-  "default": true,
-  "MD013": false,
-  "MD024": false,
-  "MD036": false,
-  "MD041": false
-}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Thank you for considering contributing! This repository contains a comprehensive
 
 - Hooks should pass ShellCheck (for bash) or basic linting
 - YAML frontmatter must be valid
-- Markdown should follow .markdownlint.yaml rules
+- Markdown should pass prettier formatting
 - No credentials, secrets, or personal data
 
 ## Pull Request Process

--- a/hooks/auto-format.sh
+++ b/hooks/auto-format.sh
@@ -29,7 +29,6 @@ case "$file_path" in
 	;;
 *.md)
 	command -v prettier &>/dev/null && prettier --write "$file_path" 2>/dev/null
-	command -v markdownlint &>/dev/null && [ -n "$file_path" ] && markdownlint --fix "$file_path" >/dev/null 2>&1
 	;;
 esac
 

--- a/rules/markdown.md
+++ b/rules/markdown.md
@@ -3,9 +3,8 @@ paths:
   - "**/*.md"
 ---
 
-- Must pass `prettier` and `markdownlint`
+- Must pass `prettier`
 - Run `bunx prettier --write <file>` to format
-- Run `bunx markdownlint <file>` to validate
 - **MD041**: Every code block must have a language tag (e.g., ` ```bash `, ` ```ts `, ` ```json `); use `text` when no other applies
 - **MD013**: Line length is not enforced
 - Always specify language tags: `bash`, `sh`, `ts`, `tsx`, `js`, `json`, `yaml`, `python`, `sql`, `html`, `css`, etc.


### PR DESCRIPTION
Remove markdownlint config, hook call, and documentation references. Prettier handles all markdown formatting.