### PR TITLE
Add repository settings configuration

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,8 @@
+_extends: .github
+
+repository:
+  name: claude-code-setup
+  description: "Comprehensive Claude Code configuration with agents, skills, hooks, and automation"
+  homepage: https://philoserf.github.io/claude-code-setup/
+  topics:
+    - claude-code


### PR DESCRIPTION
Add `.github/settings.yml` for declarative repo settings via [probot/settings](https://github.com/repository-settings/app).

This config extends the base settings from `philoserf/.github` and includes repo-specific metadata and overrides.

Settings are applied automatically when the Settings app is installed and this PR is merged.