### PR TITLE
docs: add plan mode guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,3 +26,8 @@
 - Write comments for "why", not "what"
 - Document public APIs and exported functions
 - Keep documentation close to code
+
+## Plan Mode
+
+- Ask clarifying questions about intent, scope, and trade-offs before finalizing a plan
+- Don't assume — probe for the "why" behind the request


### PR DESCRIPTION
## Summary
- Adds a "Plan Mode" section to CLAUDE.md with guidance to ask clarifying questions about intent, scope, and trade-offs before finalizing plans

## Test plan
- [ ] Verify plan mode behavior follows the new guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)