### PR TITLE
feat: enable skipDangerousModePermissionPrompt setting

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -211,5 +211,6 @@
   "statusLine": {
     "type": "command",
     "command": "~/.claude/statusline.sh"
-  }
+  },
+  "skipDangerousModePermissionPrompt": true
 }


### PR DESCRIPTION
## Summary
- Adds `skipDangerousModePermissionPrompt: true` to settings.json
- Skips the confirmation prompt when entering dangerous mode

## Test plan
- [ ] Verify dangerous mode no longer shows confirmation prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)