### PR TITLE
feat: add pdf and skill-creator skills

### DIFF
--- a/skills/pdf
+++ b/skills/pdf
@@ -1,0 +1,1 @@
+../../.agents/skills/pdf

--- a/skills/skill-creator
+++ b/skills/skill-creator
@@ -1,0 +1,1 @@
+../../.agents/skills/skill-creator


### PR DESCRIPTION
## Summary
- Adds `skills/pdf` symlink pointing to `~/.agents/skills/pdf`
- Adds `skills/skill-creator` symlink pointing to `~/.agents/skills/skill-creator`
- Both are externally-managed skills with their own LICENSE files

## Test plan
- [ ] Verify pdf skill triggers on PDF-related requests
- [ ] Verify skill-creator skill triggers on skill creation requests
- [ ] Confirm symlink targets exist on the local machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)