### PR TITLE
fix: remove stale references and update component counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A comprehensive, production-ready configuration for [Claude Code](https://claude
 
 ## What's Here
 
-- **11 Skills**: Reusable capabilities for auditing, authoring, workflows, and more
-- **9 Hooks**: Automation for validation, formatting, logging, and notifications
-- **7 Rules**: Language and tool-specific coding standards
-- **1 Command**: Quick shortcuts for common operations
+- **13 Skills**: Reusable capabilities for auditing, authoring, workflows, and more
+- **11 Hooks**: Automation for validation, formatting, logging, and notifications
+- **8 Rules**: Language and tool-specific coding standards
+- **2 Commands**: Quick shortcuts for common operations
 - **Decision guides and references**: Help choosing the right component type and naming things consistently
 
 This directory (`~/.claude`) is the global configuration directory for Claude Code. All customizations here apply across projects unless overridden locally.
@@ -55,20 +55,20 @@ Don't install this. Just steal what you like.
 
 ### Session Data (not tracked in git)
 
-| Directory          | Purpose                                 |
-| ------------------ | --------------------------------------- |
-| `projects/`        | Per-project metadata and usage tracking |
-| `todos/`           | Session-scoped todo lists               |
-| `plans/`           | Implementation plans from plan mode     |
-| `file-history/`    | Change tracking for edited files        |
-| `session-env/`     | Environment snapshots per session       |
-| `sessions/`        | Session state and conversation data     |
-| `logs/`            | Session and commit history logs         |
-| `debug/`           | Session debug output                    |
-| `shell-snapshots/` | Shell environment captures              |
-| `cache/`           | Temporary cached data                   |
-| `learned/`         | Claude's learned preferences            |
-| `history.jsonl`    | Conversation history across sessions    |
+| Directory          | Purpose                                     |
+| ------------------ | ------------------------------------------- |
+| `projects/`        | Per-project metadata and usage tracking     |
+| `todos/`           | Session-scoped todo lists                   |
+| `plans/`           | Implementation plans from plan mode         |
+| `file-history/`    | Change tracking for edited files            |
+| `session-env/`     | Environment snapshots per session           |
+| `sessions/`        | Session state and conversation data         |
+| `logs/`            | Session and commit history logs             |
+| `debug/`           | Session debug output                        |
+| `shell-snapshots/` | Shell environment captures                  |
+| `cache/`           | Temporary cached data                       |
+| `learned/`         | Claude's learned preferences (auto-managed) |
+| `history.jsonl`    | Conversation history across sessions        |
 
 ## Customizing Your Setup
 
@@ -97,19 +97,6 @@ Create a directory in `skills/` with a `SKILL.md` file:
 - Configure allowed tools
 
 **Examples**: Best practices, deployment procedures, workflow automation
-
-### Creating Output-Styles
-
-**When to use**: Define persona modes that change how Claude behaves (tone, verbosity, approach).
-
-Create a markdown file in `output-styles/`:
-
-- Define persona and role
-- Specify concrete behaviors
-- Decide scope (user vs project)
-- Set keep-coding-instructions
-
-**Examples**: Technical writer, QA tester, learning mode, concise mode
 
 ### Creating Hooks
 
@@ -241,4 +228,4 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ---
 
-**Last Updated**: 2026-02-03
+**Last Updated**: 2026-02-19

--- a/references/README.md
+++ b/references/README.md
@@ -7,15 +7,15 @@ This directory contains documentation shared across all Claude Code customizatio
 ```text
 references/
 ├── README.md (this file)
+├── agent-vs-skill-structure.md
+├── customization-examples.md
 ├── decision-matrix.md
-├── when-to-use-what.md
-├── naming-conventions.md
-├── frontmatter-requirements.md
-├── delegation-patterns.md
-├── hook-events.md
-├── plugin-structure-comparison.md
 ├── file-organization.md
-└── customization-examples.md
+├── frontmatter-requirements.md
+├── hook-events.md
+├── naming-conventions.md
+├── plugin-structure-comparison.md
+└── when-to-use-what.md
 ```
 
 ## Customization Development References
@@ -67,15 +67,6 @@ All files support creating and auditing Claude Code extensions (skills, agents, 
 - Use when: Organizing customization files
 
 ### Reference Documentation
-
-**[delegation-patterns.md](delegation-patterns.md)** (595 lines)
-
-- Command delegation patterns and best practices
-- 4 valid patterns: Descriptive delegation, standalone prompts, bash execution,
-  file references
-- Clear vs unclear delegation examples
-- Use when: Writing commands or validating delegation clarity
-- Referenced by: authoring and audit skills
 
 **[hook-events.md](hook-events.md)** (241 lines)
 
@@ -183,8 +174,8 @@ When updating shared references:
 
 ---
 
-Last updated: 2026-01-28
-File count: 9 files (decision-matrix.md, when-to-use-what.md,
-naming-conventions.md, frontmatter-requirements.md, delegation-patterns.md,
-hook-events.md, plugin-structure-comparison.md, file-organization.md,
-customization-examples.md)
+Last updated: 2026-02-19
+File count: 9 files (agent-vs-skill-structure.md, customization-examples.md,
+decision-matrix.md, file-organization.md, frontmatter-requirements.md,
+hook-events.md, naming-conventions.md, plugin-structure-comparison.md,
+when-to-use-what.md)

--- a/references/customization-examples.md
+++ b/references/customization-examples.md
@@ -8,11 +8,10 @@ Practical examples of well-named and organized Claude Code components.
 
 ```text
 .claude/agents/
-├── cc-check.md           # Tests Claude Code customizations
 ├── code-reviewer.md           # Reviews code for quality issues
-├── security-reviewer.md       # Security-focused code review
 ├── performance-optimizer.md   # Analyzes and optimizes performance
-└── debugger.md                # Debugs errors and failures
+├── debugger.md                # Debugs errors and failures
+└── api-designer.md            # Designs REST/GraphQL APIs
 ```
 
 ### Domain-Specific Agents

--- a/references/naming-conventions.md
+++ b/references/naming-conventions.md
@@ -22,8 +22,7 @@ Consistent naming patterns for Claude Code subagents, skills, and hooks to impro
 
 ### Examples
 
-- `cc-check.md` - Tests Claude Code customizations
-- `security-reviewer.md` - Reviews code for security issues
+- `code-reviewer.md` - Reviews code for quality issues
 - `api-designer.md` - Designs API endpoints and contracts
 - `performance-optimizer.md` - Analyzes and optimizes performance
 - `debugger.md` - Debugs errors and unexpected behavior

--- a/references/plugin-structure-comparison.md
+++ b/references/plugin-structure-comparison.md
@@ -103,7 +103,7 @@ skills/
 ```
 
 - ✅ **We use this**: Current skills/ directory follows this pattern
-- **Current count**: 17 skills (approaching upper limit)
+- **Current count**: 13 skills
 
 #### Categorized Structure (15+ components)
 
@@ -144,8 +144,8 @@ skills/
 
 **Current Structure Assessment**:
 
-- 17 skills total
-- Natural groupings exist: audit-_,_-authoring, version-control
+- 13 skills total
+- Natural groupings exist: audit, quality, version-control
 - Flat structure still manageable but approaching limits
 - **Recommendation**: Document categorization plan for future
 
@@ -215,40 +215,35 @@ agents/agent-name/
 - Component-specific details in each component
 - Clear delineation of scope
 
-**Our Implementation** (updated 2026-01-06):
+**Our Implementation** (updated 2026-02-19):
 
 ```text
 ~/.claude/
-├── references/              # Shared across ALL components
-│   ├── customization/      # Shared customization docs
-│   │   ├── decision-matrix.md
-│   │   ├── when-to-use-what.md
-│   │   ├── naming-conventions.md
-│   │   └── plugin-structure-comparison.md
-│   └── map-codebase-workflow.md
+├── references/              # Shared across ALL components (flat)
+│   ├── decision-matrix.md
+│   ├── naming-conventions.md
+│   ├── when-to-use-what.md
+│   └── ...
 ├── skills/
 │   └── skill-name/
 │       ├── SKILL.md         # Main skill file
 │       └── reference.md     # Skill-specific reference (flattened)
 └── agents/
-    └── agent-name/
-        ├── agent-name.md    # Main agent file
-        └── references/      # Agent-specific references (subdirectory)
-            └── file.md
+    └── agent-name.md        # Single-file agent (most common)
 ```
 
 **Status**:
 
 - ✅ **Well defined**: Clear shared vs component-specific separation
 - ✅ **Documented**: references/README.md explains the distinction
-- ✅ **Updated**: Reflects skill flattening and agent subdirectory pattern
+- ✅ **Updated**: Reflects skill flattening and flat references layout
 - ✅ **Consistent**: Components reference shared docs using `../../references/`
 
 **Key Differences from Official**:
 
 - Skills: Flattened structure (no subdirectories)
-- Agents: Must use `references/` subdirectory (validation constraint)
-- Global references organized in `customization/` subfolder
+- Agents: Single-file for simple agents; `references/` subdirectory for complex ones
+- Global references organized flat in `references/`
 
 ### 5. Cross-Component Patterns
 
@@ -342,7 +337,7 @@ Good examples:
 
 **Our Status**:
 
-- Current: 17 skills, manageable
+- Current: 13 skills, manageable
 - Threshold: ~20 skills for categorization
 - Plan: Document in this file for future reference
 
@@ -390,21 +385,20 @@ Not applicable to personal configuration:
    - See `references/agent-vs-skill-structure.md` for rationale
 
 3. ✅ **Organized global references**
-   - Created `references/customization/` subfolder
+   - Flat layout in `references/` directory
    - Clear separation of concerns
 
 ### Current Status
 
-**Skills** (17 total):
+**Skills** (13 total):
 
 - Using flattened structure successfully
 - Reference files co-located with SKILL.md
 - Examples integrated into skills (e.g., `examples.md`)
 
-**Agents** (2 total):
+**Agents** (1 total):
 
-- cc-lint (single file)
-- cc-check (with references/ subdirectory)
+- code-reviewer (single file)
 
 ### Future Considerations
 
@@ -448,8 +442,8 @@ The official plugin-structure skill provides excellent patterns that we've succe
 **Key Adaptations**:
 
 - **Skills**: Flattened structure (validation allows it)
-- **Agents**: Subdirectory structure (validation requires it)
-- **Global references**: Organized in customization/ subfolder
+- **Agents**: Single-file for simple agents; subdirectory for complex ones
+- **Global references**: Flat layout in `references/`
 - See `references/agent-vs-skill-structure.md` for detailed rationale
 
 **Future Growth Paths**:
@@ -472,4 +466,5 @@ Our local setup has evolved beyond the initial comparison to establish patterns 
 **Created**: 2026-01-03
 **Updated**: 2026-01-06 (skill flattening, agent resources)
 **Official Source**: <https://github.com/anthropics/claude-code/tree/main/plugins/plugin-dev/skills/plugin-structure>
-**Local Context**: ~/.claude global configuration (15 skills, 2 agents, 6 hooks)
+**Updated**: 2026-02-19 (corrected component counts, updated reference layout)
+**Local Context**: ~/.claude global configuration (13 skills, 1 agent, 11 hooks)


### PR DESCRIPTION
## Summary

- Remove broken `delegation-patterns.md` links from `references/README.md`
- Replace removed `security-reviewer` examples with existing `code-reviewer` agent in naming-conventions and customization-examples
- Update `plugin-structure-comparison.md`: correct to 13 skills, 1 agent, 11 hooks; fix stale `references/customization/` path to flat `references/` layout
- Update `README.md` counts (13 skills, 11 hooks, 8 rules, 2 commands) and remove stale output-styles creation section

## Test plan

- [x] `grep -r delegation-patterns` returns no matches
- [x] All referenced files in `references/README.md` directory listing exist
- [x] Component counts match actual inventory (13 skills, 1 agent, 11 hooks, 8 rules, 2 commands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)