### PR TITLE
fix: correct claude-md-improver frontmatter and add Stop hook timeouts

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -162,11 +162,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/hooks/session-end.js"
+            "command": "~/.claude/hooks/session-end.js",
+            "timeout": 30
           },
           {
             "type": "command",
-            "command": "~/.claude/hooks/evaluate-session.js"
+            "command": "~/.claude/hooks/evaluate-session.js",
+            "timeout": 30
           }
         ]
       },

--- a/skills/claude-md-improver/SKILL.md
+++ b/skills/claude-md-improver/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: claude-md-improver
 description: Audit and improve CLAUDE.md files in repositories. Use when user asks to check, audit, review, evaluate, update, improve, optimize, clean up, or fix CLAUDE.md files. Scans for all CLAUDE.md files, evaluates quality against templates, outputs quality report, then makes targeted updates. Also use when the user mentions "CLAUDE.md maintenance", "project memory optimization", or "what should my CLAUDE.md contain".
-tools: Read, Glob, Grep, Edit
+allowed-tools: [Read, Glob, Grep, Edit]
 ---
 
 # CLAUDE.md Improver


### PR DESCRIPTION
## Summary

- Fix `claude-md-improver` SKILL.md: change `tools:` to `allowed-tools:` with YAML array format (was using wrong frontmatter key)
- Add explicit 30s timeouts to `session-end.js` and `evaluate-session.js` Stop hooks (all other hooks already had timeouts)

## Test plan

- [x] `claude-md-improver` frontmatter uses `allowed-tools:` matching all other skills
- [x] All hooks in `settings.json` now have explicit `timeout` fields
- [x] 30s timeout is reasonable for session-end file I/O operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)