### PR TITLE
fix: use YAML array format for allowed-tools in automation-recommender

### DIFF
--- a/skills/claude-automation-recommender/SKILL.md
+++ b/skills/claude-automation-recommender/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: claude-automation-recommender
 description: Analyze a codebase and recommend Claude Code automations (hooks, subagents, skills, plugins, MCP servers). Use when user asks for automation recommendations, wants to optimize their Claude Code setup, mentions improving Claude Code workflows, asks how to first set up Claude Code for a project, wants to know what Claude Code features they should use, asks about Claude Code best practices, or wants to know what tools to install for Claude Code.
-allowed-tools: Read, Glob, Grep, WebSearch
+allowed-tools: [Read, Glob, Grep, WebSearch]
 ---
 
 # Claude Automation Recommender


### PR DESCRIPTION
## Summary

- Change `allowed-tools: Read, Glob, Grep, WebSearch` to `allowed-tools: [Read, Glob, Grep, WebSearch]` in claude-automation-recommender SKILL.md
- Aligns with YAML array format used by all other skills

## Test plan

- [x] All 13 skills now use consistent `allowed-tools:` array format

🤖 Generated with [Claude Code](https://claude.com/claude-code)