### PR TITLE
fix: resolve cc-lint findings across skills and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive, production-ready configuration for [Claude Code](https://claude
 
 ## What's Here
 
-- **16 Skills**: Reusable capabilities for auditing, authoring, workflows, and more
+- **14 Skills**: Reusable capabilities for auditing, authoring, workflows, and more
 - **11 Hooks**: Automation for validation, formatting, logging, and notifications
 - **8 Rules**: Language and tool-specific coding standards
 - **2 Commands**: Quick shortcuts for common operations
@@ -52,6 +52,7 @@ Don't install this. Just steal what you like.
 | `agents/`     | Specialized AI agents for specific workflows    |
 | `skills/`     | Reusable capabilities and knowledge domains     |
 | `hooks/`      | Event-driven automation and validation          |
+| `hooks/lib/`  | Shared helper libraries for hook scripts        |
 | `rules/`      | Language and tool-specific coding standards     |
 | `commands/`   | Slash command shortcuts                         |
 | `references/` | Shared decision guides and naming conventions   |
@@ -120,12 +121,16 @@ Create a shell script in the `hooks/` directory, then configure it in `settings.
 ```json
 {
   "hooks": {
-    "preToolUse": [
+    "PreToolUse": [
       {
-        "name": "my-hook",
-        "shell": "/Users/markayers/.claude/hooks/my-hook.sh",
-        "matchers": ["Bash.*"],
-        "timeoutMs": 5000
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/my-hook.sh",
+            "timeout": 5
+          }
+        ]
       }
     ]
   }
@@ -145,8 +150,8 @@ Claude Code requires explicit permissions for tool operations. Configure in `set
 ```json
 {
   "permissions": {
-    "allowed": ["Read", "Bash(git:*)", "Write(*.md)"],
-    "denied": ["Read(.env*)", "Bash(sudo:*)"]
+    "allow": ["Read", "Bash(git:*)", "Write(*.md)"],
+    "deny": ["Read(.env*)", "Bash(sudo:*)"]
   }
 }
 ```

--- a/skills/claude-automation-recommender/references/skills-reference.md
+++ b/skills/claude-automation-recommender/references/skills-reference.md
@@ -86,7 +86,7 @@ name: skill-name
 description: What this skill does and when to use it
 disable-model-invocation: true  # Only user can invoke (for side effects)
 user-invocable: false           # Only Claude can invoke (for background knowledge)
-allowed-tools: Read, Grep, Glob # Restrict tool access
+allowed-tools: Read Grep Glob   # Restrict tool access
 context: fork                   # Run in isolated subagent
 agent: Explore                  # Which agent type when forked
 ---
@@ -173,7 +173,7 @@ Generate and validate migrations using a bundled script:
 name: create-migration
 description: Create a database migration file
 disable-model-invocation: true
-allowed-tools: Read, Write, Bash
+allowed-tools: Read Write Bash
 ---
 
 Create a migration for: $ARGUMENTS

--- a/skills/improve-instructions/SKILL.md
+++ b/skills/improve-instructions/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   preferences and corrections. Use when Claude keeps repeating a mistake, when
   you want to teach it a new preference, or when consolidating guidance from
   repeated instructions.
-allowed-tools: Read Edit Grep Glob AskUserQuestion TodoWrite
+allowed-tools: Read Edit Grep Glob AskUserQuestion
 ---
 
 ## Reference Files
@@ -35,7 +35,7 @@ Review the conversation history for:
 - **Misunderstandings** - Where Claude made wrong assumptions
 - **Undocumented patterns** - Tools or workflows used frequently
 
-Use TodoWrite to track each potential improvement identified.
+Track each potential improvement identified.
 
 ### Phase 2: Review Current State
 

--- a/skills/map-codebase/SKILL.md
+++ b/skills/map-codebase/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   documentation in .planning/codebase/. Covers stack, architecture,
   conventions, testing, and integrations. Use for project onboarding, refreshing
   understanding after major changes, or before a large refactoring effort.
-allowed-tools: Read Write Glob Grep Bash Task
+allowed-tools: Read Write Glob Grep Bash
 ---
 
 ## Reference Files
@@ -113,11 +113,11 @@ Launch 4 Explore agents in parallel, each with "very thorough" exploration level
 - Focus: Issues, risks, technical debt, potential improvements
 - Outputs: Data for CONCERNS.md
 
-### Step 5: Collect Agent Findings
+### Step 6: Collect Agent Findings
 
 Wait for all agents to complete. Collect and organize findings by document type.
 
-### Step 6: Write Core Documents
+### Step 7: Write Core Documents
 
 Write 4 core markdown documents in `.planning/`:
 
@@ -126,7 +126,7 @@ Write 4 core markdown documents in `.planning/`:
 **STRUCTURE.md**: Directory layout, modules, naming patterns, organization  
 **CONVENTIONS.md**: Code style, naming conventions, patterns, documentation
 
-### Step 7: Write Optional Documents (if selected)
+### Step 8: Write Optional Documents (if selected)
 
 Generate only selected optional documents:
 
@@ -134,7 +134,7 @@ Generate only selected optional documents:
 **INTEGRATIONS.md** (if applicable): External APIs, databases, third-party services, config  
 **CONCERNS.md** (if applicable): Tech debt, issues, security, performance, improvements
 
-### Step 8: Provide Next Steps
+### Step 9: Provide Next Steps
 
 Inform user codebase mapping is complete:
 

--- a/skills/session-review/SKILL.md
+++ b/skills/session-review/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Produces a structured review capturing what worked and what to improve. Use
   for session retrospectives, debriefs, post-mortems, or when reflecting on
   insights worth remembering.
-allowed-tools: Read Write Edit Grep Glob AskUserQuestion TodoWrite
+allowed-tools: Read Write Edit Grep Glob AskUserQuestion
 ---
 
 ## Reference Files

--- a/skills/tdd-cycle/SKILL.md
+++ b/skills/tdd-cycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd-cycle
-description: >
+description: >-
   Enforce strict red-green-refactor TDD cycles with phase gates. Use when
   doing TDD, test-driven development, red green refactor, write tests first,
   test-first development, failing test, or make tests pass.

--- a/skills/tech-debt/SKILL.md
+++ b/skills/tech-debt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tech-debt
-description: >
+description: >-
   Identify, classify, and prioritize technical debt with a remediation roadmap.
   Use when auditing technical debt, assessing code quality, analyzing maintenance
   burden, inventorying legacy code, or asking what's slowing us down.


### PR DESCRIPTION
## Summary

- Update README hook config example to match actual `settings.json` schema (`PreToolUse`, `matcher`, `hooks` array with `type`/`command`/`timeout`)
- Fix permissions field names in README: `allowed`→`allow`, `denied`→`deny`
- Document `hooks/lib/` in Extension Directories table
- Remove `Task` from map-codebase allowed-tools and fix duplicate step numbering (Steps 5→9)
- Fix comma-separated `allowed-tools` examples in skills-reference to space-delimited
- Remove `TodoWrite` from session-review and improve-instructions allowed-tools
- Fix YAML folded scalar `>` to strip-trailing `>-` in tdd-cycle and tech-debt descriptions
- Update skill count from 16 to 14

## Test plan

- [x] Run `/cc-lint` — all 10 targeted findings resolved
- [x] Verify YAML frontmatter parses correctly (`skill-validator check skills/`)
- [x] Spot-check README examples against actual `settings.json` schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)