### PR TITLE
fix: resolve cc-lint findings across commands, agent, and skills

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: code-reviewer
 description: Reviews code changes for quality, security, and style issues. Use before committing or when asked to review code.
-model: sonnet
 tools:
   - Read
   - Grep

--- a/commands/deps-audit.md
+++ b/commands/deps-audit.md
@@ -1,4 +1,5 @@
 ---
+name: deps-audit
 description: Audit project dependencies for vulnerabilities, outdated packages, and license issues
 ---
 

--- a/commands/vc-sync.md
+++ b/commands/vc-sync.md
@@ -1,4 +1,5 @@
 ---
+name: vc-sync
 description: Sync local repo - switch to main, update from remote, clean merged branches
 ---
 

--- a/skills/cc-lint/SKILL.md
+++ b/skills/cc-lint/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-lint
-description: Quick structural validation of Claude Code customizations. Checks YAML syntax, required fields, naming conventions, and file organization. Use for fast correctness checks, linting, checking syntax, or verifying YAML.
+description: Quick structural validation of Claude Code customizations. Checks YAML syntax, required fields, naming conventions, file organization, and settings.json health. Use for fast correctness checks, linting, checking syntax, verifying YAML, or validating component structure.
 allowed-tools: Read Glob Grep Bash
 ---
 

--- a/skills/cc-plan/SKILL.md
+++ b/skills/cc-plan/SKILL.md
@@ -3,7 +3,8 @@ name: cc-plan
 description: >-
   Interviews the user to plan a feature and produce a PRD. Covers scoping
   requirements, defining specs, and designing solutions. Use when starting new
-  work that needs planning or requirements definition.
+  work that needs planning, requirements definition, feature scoping, or
+  creating a product requirements document.
 allowed-tools: Read AskUserQuestion
 ---
 


### PR DESCRIPTION
## Summary

- Add missing `name` field to `commands/vc-sync.md` and `commands/deps-audit.md`
- Remove non-standard `model: sonnet` field from `agents/code-reviewer.md`
- Expand descriptions for `skills/cc-lint` and `skills/cc-plan` to meet 200-char minimum

## Test plan

- [x] Ran `/cc-lint` — all 37 components pass
- [x] Verified each fixed file individually

🤖 Generated with [Claude Code](https://claude.com/claude-code)