### PR TITLE
fix: restore markdown anchor links across skill files

### DIFF
--- a/skills/cc-check/SKILL.md
+++ b/skills/cc-check/SKILL.md
@@ -93,11 +93,11 @@ For each test:
 
 ### Step 6: Generate Test Report
 
-Create structured report following [report-template.md](references/report-template.md).
+Create structured report following [report-template.md](references/report-template.md#template).
 
 ## Output Format
 
-Test reports follow a structured format. See [report-template.md](references/report-template.md) for the complete template.
+Test reports follow a structured format. See [report-template.md](references/report-template.md#template) for the complete template.
 
 **Key sections**: Summary, Test Results, Functional Tests, Integration Tests, Usability Assessment, Edge Cases, Recommendations
 
@@ -116,7 +116,7 @@ Test reports follow a structured format. See [report-template.md](references/rep
 
 ## Common Test Failures
 
-For failure patterns and fixes by customization type, see [common-failures.md](references/common-failures.md).
+For failure patterns and fixes by customization type, see [common-failures.md](references/common-failures.md#skills).
 
 ## Tools Used
 

--- a/skills/cc-lint/references/evaluation-process.md
+++ b/skills/cc-lint/references/evaluation-process.md
@@ -86,4 +86,4 @@ For skills and agents with allowed-tools:
 
 ## Step 6: Generate Structured Report
 
-Create comprehensive evaluation following the report format (see [report-format.md](report-format.md)).
+Create comprehensive evaluation following the report format (see [report-format.md](report-format.md#report-template)).

--- a/skills/claude-automation-recommender/SKILL.md
+++ b/skills/claude-automation-recommender/SKILL.md
@@ -133,7 +133,7 @@ See [subagent-templates.md](references/subagent-templates.md) for templates.
 
 #### E. Plugin Recommendations
 
-See [plugins-reference.md](references/plugins-reference.md) for available plugins.
+See [plugins-reference.md](references/plugins-reference.md#official-plugins) for available plugins.
 
 | Codebase Signal      | Recommended Plugin                              |
 | -------------------- | ----------------------------------------------- |
@@ -143,7 +143,7 @@ See [plugins-reference.md](references/plugins-reference.md) for available plugin
 
 ### Phase 3: Output Recommendations Report
 
-See [output-template.md](references/output-template.md) for the full report template. Only include 1-2 recommendations per category — the most valuable ones for this specific codebase. Skip irrelevant categories.
+See [output-template.md](references/output-template.md#claude-code-automation-recommendations) for the full report template. Only include 1-2 recommendations per category — the most valuable ones for this specific codebase. Skip irrelevant categories.
 
 ## Reference Files
 

--- a/skills/claude-md-improver/SKILL.md
+++ b/skills/claude-md-improver/SKILL.md
@@ -51,7 +51,7 @@ Patterns: **/CLAUDE.md, **/.claude.md, **/.claude.local.md
 
 ### Phase 2: Quality Assessment
 
-For each CLAUDE.md file, evaluate against quality criteria. See [quality-criteria.md](references/quality-criteria.md) for detailed rubrics.
+For each CLAUDE.md file, evaluate against quality criteria. See [quality-criteria.md](references/quality-criteria.md#scoring-rubric) for detailed rubrics.
 
 **Quick Assessment Checklist:**
 
@@ -177,4 +177,4 @@ See [templates.md](references/templates.md) for CLAUDE.md templates by project t
 
 ## What Makes a Great CLAUDE.md
 
-See [templates.md](references/templates.md) for templates and key principles. In short: concise, actionable, project-specific, with non-obvious gotchas.
+See [templates.md](references/templates.md#key-principles) for templates and key principles. In short: concise, actionable, project-specific, with non-obvious gotchas.

--- a/skills/refactor-clean/SKILL.md
+++ b/skills/refactor-clean/SKILL.md
@@ -35,7 +35,7 @@ Systematic methodology for analyzing and refactoring code to improve quality, ma
 
 ### 1. Analyze
 
-Read the target code and identify issues using the [analysis rubric](./references/analysis-rubric.md).
+Read the target code and identify issues using the [analysis rubric](./references/analysis-rubric.md#code-smell-detection).
 
 - Map function/class boundaries and responsibilities
 - Flag code smells with specific locations and threshold violations
@@ -71,7 +71,7 @@ Principles to follow: DRY, YAGNI, composition over inheritance, consistent abstr
 
 ### 4. Verify
 
-Run existing tests after each incremental change. Check against the [quality checklist](./references/quality-checklist.md).
+Run existing tests after each incremental change. Check against the [quality checklist](./references/quality-checklist.md#acceptance-criteria).
 
 - Detect test runner: check for package.json scripts, Makefile targets, pytest, go test, cargo test
 - Run the suite and confirm all tests pass

--- a/skills/skill-improve/SKILL.md
+++ b/skills/skill-improve/SKILL.md
@@ -30,7 +30,7 @@ This skill generates actionable, prioritized improvement recommendations for Cla
 | **Clarity**          | Wording, consistency, formatting           |
 | **Tool Permissions** | Appropriateness, minimalism, security      |
 
-See [improvement-categories.md](references/improvement-categories.md) for detailed guidance on each category.
+See [improvement-categories.md](references/improvement-categories.md#overview) for detailed guidance on each category.
 
 ## Priority Levels
 
@@ -44,7 +44,7 @@ Recommendations are prioritized by impact and effort:
 | **P4**   | Medium | High   | Consider - Weigh cost vs benefit      |
 | **P5**   | Low    | Any    | Nice to Have - Optional polish        |
 
-See [prioritization-guide.md](references/prioritization-guide.md) for the complete impact/effort matrix.
+See [prioritization-guide.md](references/prioritization-guide.md#impacteffort-matrix) for the complete impact/effort matrix.
 
 ## Evaluation Process
 
@@ -136,7 +136,7 @@ Reports include:
 - Specific implementation guidance
 - Optional before/after examples
 
-See [report-template.md](references/report-template.md) for the complete output format.
+See [report-template.md](references/report-template.md#report-structure) for the complete output format.
 
 ## Relationship to Other Skills
 

--- a/skills/skill-quality/SKILL.md
+++ b/skills/skill-quality/SKILL.md
@@ -47,10 +47,10 @@ Based on weighted average score:
 1. **Run skill-validator** - Structural checks first (see [Automated Validation](#automated-validation))
 2. **Locate the skill** - Find SKILL.md and all reference files
 3. **Read all content** - Examine main file and supporting documentation
-4. **Score each dimension** - Apply rubric criteria, informed by validator output (see [scoring-rubric.md](references/scoring-rubric.md))
+4. **Score each dimension** - Apply rubric criteria, informed by validator output (see [scoring-rubric.md](references/scoring-rubric.md#score-definitions))
 5. **Calculate weighted average** - Compute overall score
 6. **Determine quality tier** - Map score to tier
-7. **Generate report** - Include validator summary and dimension scores (see [report-template.md](references/report-template.md))
+7. **Generate report** - Include validator summary and dimension scores (see [report-template.md](references/report-template.md#report-structure))
 
 ## Automated Validation
 
@@ -93,8 +93,8 @@ The validator checks structure (SKILL.md presence, file organization), frontmatt
 
 **For each dimension**:
 
-1. Review the dimension criteria in [quality-dimensions.md](references/quality-dimensions.md)
-2. Apply the 1-5 rubric from [scoring-rubric.md](references/scoring-rubric.md)
+1. Review the dimension criteria in [quality-dimensions.md](references/quality-dimensions.md#overview)
+2. Apply the 1-5 rubric from [scoring-rubric.md](references/scoring-rubric.md#score-definitions)
 3. Document specific evidence supporting the score
 4. Note any borderline cases or scoring rationale
 
@@ -146,7 +146,7 @@ Reports include:
 - Dimension-specific observations
 - Optional comparison to other skills
 
-See [report-template.md](references/report-template.md) for the complete output format.
+See [report-template.md](references/report-template.md#report-structure) for the complete output format.
 
 ## Relationship to Other Tools
 

--- a/skills/tdd-cycle/SKILL.md
+++ b/skills/tdd-cycle/SKILL.md
@@ -33,7 +33,7 @@ Strict red-green-refactor cycle enforcement. Every line of production code is ju
 
 - **tdd-cycle** owns phase discipline: when to write tests, when to implement, when to refactor, and transition gates between phases
 - **refactor-clean** owns refactoring methodology: what smells to detect, how to prioritize, how to verify quality
-- The REFACTOR phase delegates smell detection and prioritization to `refactor-clean`'s [analysis rubric](../refactor-clean/references/analysis-rubric.md)
+- The REFACTOR phase delegates smell detection and prioritization to `refactor-clean`'s [analysis rubric](../refactor-clean/references/analysis-rubric.md#code-smell-detection)
 
 ## Development Modes
 
@@ -62,7 +62,7 @@ Analyze requirements and identify test scenarios before writing any code.
 
 Write tests that define the expected behavior. No implementation code yet.
 
-Follow the [RED phase rules](./references/phase-discipline.md) strictly:
+Follow the [RED phase rules](./references/phase-discipline.md#red-phase) strictly:
 
 - Tests must fail due to missing implementation, not syntax or import errors
 - Each test targets one specific behavior
@@ -75,7 +75,7 @@ Follow the [RED phase rules](./references/phase-discipline.md) strictly:
 
 Write the minimum code to make tests pass. Nothing more.
 
-Follow the [GREEN phase rules](./references/phase-discipline.md) strictly:
+Follow the [GREEN phase rules](./references/phase-discipline.md#green-phase) strictly:
 
 - Choose the right technique: Fake It, Obvious Implementation, or Triangulation
 - One test at a time in incremental mode; run after each change
@@ -88,10 +88,10 @@ Follow the [GREEN phase rules](./references/phase-discipline.md) strictly:
 
 Improve code quality while keeping all tests green.
 
-Follow the [REFACTOR phase rules](./references/phase-discipline.md) strictly:
+Follow the [REFACTOR phase rules](./references/phase-discipline.md#refactor-phase) strictly:
 
 - Refactor both production code and test code
-- Use `refactor-clean`'s [analysis rubric](../refactor-clean/references/analysis-rubric.md) to identify smells
+- Use `refactor-clean`'s [analysis rubric](../refactor-clean/references/analysis-rubric.md#code-smell-detection) to identify smells
 - One atomic change at a time, run tests after each
 - Revert immediately if any test breaks
 - No behavior changes — if new behavior is needed, go back to RED
@@ -100,7 +100,7 @@ Follow the [REFACTOR phase rules](./references/phase-discipline.md) strictly:
 
 ### 5. Repeat
 
-Pick the next test scenario and return to step 2. Continue until all identified behaviors are covered and [coverage thresholds](./references/thresholds.md) are met.
+Pick the next test scenario and return to step 2. Continue until all identified behaviors are covered and [coverage thresholds](./references/thresholds.md#coverage-thresholds) are met.
 
 ## Output Format
 

--- a/skills/tdd-cycle/references/phase-discipline.md
+++ b/skills/tdd-cycle/references/phase-discipline.md
@@ -83,7 +83,7 @@ Refactor both production code and test code:
 - **Production code:** extract methods, rename for clarity, reduce duplication, simplify conditionals
 - **Test code:** extract shared fixtures, improve test names, remove duplication between tests
 
-Use the `refactor-clean` skill's [analysis rubric](../../refactor-clean/references/analysis-rubric.md) to identify which smells to address and in what priority order.
+Use the `refactor-clean` skill's [analysis rubric](../../refactor-clean/references/analysis-rubric.md#code-smell-detection) to identify which smells to address and in what priority order.
 
 ### Rules
 

--- a/skills/tech-debt/SKILL.md
+++ b/skills/tech-debt/SKILL.md
@@ -43,7 +43,7 @@ Run `tech-debt` first to build the inventory, then hand prioritized items to `re
 
 ### 1. Scan
 
-Walk the codebase and identify debt items using the [debt categories](./references/debt-categories.md).
+Walk the codebase and identify debt items using the [debt categories](./references/debt-categories.md#code-debt).
 
 - Glob for project structure and file sizes
 - Grep for known smell patterns (TODO/FIXME/HACK, deeply nested code, large files)
@@ -52,7 +52,7 @@ Walk the codebase and identify debt items using the [debt categories](./referenc
 
 ### 2. Assess
 
-Score each debt item using the [ROI framework](./references/roi-framework.md).
+Score each debt item using the [ROI framework](./references/roi-framework.md#impact-dimensions).
 
 - Evaluate impact across velocity, quality, and risk dimensions
 - Assign a risk level (Critical / High / Medium / Low)

--- a/skills/vc-ship/SKILL.md
+++ b/skills/vc-ship/SKILL.md
@@ -51,16 +51,16 @@ The skill follows an 8-phase workflow:
 6. **Push with Confirmation** - Push changes to remote after approval
 7. **Pull Request Creation** - Optionally create PR with generated description
 
-| Phase | Goal                | Key Actions                                              | Reference                                                               |
-| ----- | ------------------- | -------------------------------------------------------- | ----------------------------------------------------------------------- |
-| 0     | Branch Management   | Block protected branches, suggest feature branch         | [phase-0-protocol.md](references/phase-0-protocol.md)                   |
-| 1     | Repository Analysis | Check status, diffs, detect conflicts                    | [workflow-phases.md](references/workflow-phases.md)                     |
-| 2     | Organize Commits    | Group related changes, create commit plan                | [workflow-phases.md](references/workflow-phases.md)                     |
-| 3     | Create Commits      | Stage files, format messages, execute commits            | [commit-format.md](references/commit-format.md)                         |
-| 4     | History Cleanup     | Squash/reword commits (optional, use `git reset --soft`) | [rebase-guide.md](references/rebase-guide.md)                           |
-| 5     | Quality Review      | Check message quality, offer tests (**mandatory**)       | [phase-5-protocol.md](references/phase-5-protocol.md)                   |
-| 6     | Push                | Block protected branches, confirm, push with `-u`        | [protected-branch-protocol.md](references/protected-branch-protocol.md) |
-| 7     | Pull Request        | Generate PR title/description, create via `gh`           | [workflow-phases.md](references/workflow-phases.md)                     |
+| Phase | Goal                | Key Actions                                              | Reference                                                                                  |
+| ----- | ------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| 0     | Branch Management   | Block protected branches, suggest feature branch         | [phase-0-protocol.md](references/phase-0-protocol.md)                                      |
+| 1     | Repository Analysis | Check status, diffs, detect conflicts                    | [workflow-phases.md](references/workflow-phases.md#phase-1-repository-analysis)            |
+| 2     | Organize Commits    | Group related changes, create commit plan                | [workflow-phases.md](references/workflow-phases.md#phase-2-organize-into-atomic-commits)   |
+| 3     | Create Commits      | Stage files, format messages, execute commits            | [commit-format.md](references/commit-format.md)                                            |
+| 4     | History Cleanup     | Squash/reword commits (optional, use `git reset --soft`) | [rebase-guide.md](references/rebase-guide.md)                                              |
+| 5     | Quality Review      | Check message quality, offer tests (**mandatory**)       | [phase-5-protocol.md](references/phase-5-protocol.md)                                      |
+| 6     | Push                | Block protected branches, confirm, push with `-u`        | [protected-branch-protocol.md](references/protected-branch-protocol.md)                    |
+| 7     | Pull Request        | Generate PR title/description, create via `gh`           | [workflow-phases.md](references/workflow-phases.md#phase-7-pull-request-creation-optional) |
 
 **Key rules:**
 
@@ -70,16 +70,16 @@ The skill follows an 8-phase workflow:
 
 ## Edge Case Quick Reference
 
-| Situation                   | Action                                                                                    |
-| --------------------------- | ----------------------------------------------------------------------------------------- |
-| No changes                  | Inform user, exit gracefully                                                              |
-| Untracked files             | List, ask about inclusion, suggest .gitignore for secrets                                 |
-| Large changeset (10+ files) | Suggest splitting into multiple PRs                                                       |
-| Detached HEAD               | Alert user, offer to create branch                                                        |
-| Merge conflicts             | STOP, show files, guide resolution                                                        |
-| No remote                   | Offer to add origin                                                                       |
-| Protected branch            | BLOCK, require feature branch (see [phase-0-protocol.md](references/phase-0-protocol.md)) |
-| Rebase in progress          | Alert, offer continue or abort                                                            |
+| Situation                   | Action                                                                                                                             |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| No changes                  | Inform user, exit gracefully                                                                                                       |
+| Untracked files             | List, ask about inclusion, suggest .gitignore for secrets                                                                          |
+| Large changeset (10+ files) | Suggest splitting into multiple PRs                                                                                                |
+| Detached HEAD               | Alert user, offer to create branch                                                                                                 |
+| Merge conflicts             | STOP, show files, guide resolution                                                                                                 |
+| No remote                   | Offer to add origin                                                                                                                |
+| Protected branch            | BLOCK, require feature branch (see [phase-0-protocol.md](references/phase-0-protocol.md#scenario-1-uncommitted-changes--blocking)) |
+| Rebase in progress          | Alert, offer continue or abort                                                                                                     |
 
 ## User Interaction Patterns
 

--- a/skills/vc-ship/references/phase-0-protocol.md
+++ b/skills/vc-ship/references/phase-0-protocol.md
@@ -4,7 +4,7 @@ Prevents direct work on protected branches by detecting uncommitted changes earl
 
 **Philosophy**: Catch mistakes early — before you invest time in work that's hard to migrate.
 
-**Note**: This is Phase 0 protection (start-of-work). For Phase 6 protection (push-time), see [protected-branch-protocol.md](protected-branch-protocol.md).
+**Note**: This is Phase 0 protection (start-of-work). For Phase 6 protection (push-time), see [protected-branch-protocol.md](protected-branch-protocol.md#when-protected-branch-detected).
 
 ## Detection Order
 

--- a/skills/vc-ship/references/protected-branch-protocol.md
+++ b/skills/vc-ship/references/protected-branch-protocol.md
@@ -4,7 +4,7 @@ Prevents direct **pushes** to protected branches (main/master/develop/production
 
 **Philosophy**: Easier to override when you know what you're doing than to undo a bad push to main.
 
-**Note**: This is Phase 6 protection (push-time). For Phase 0 protection (start-of-work), see [phase-0-protocol.md](phase-0-protocol.md).
+**Note**: This is Phase 6 protection (push-time). For Phase 0 protection (start-of-work), see [phase-0-protocol.md](phase-0-protocol.md#detection-order).
 
 ## Detection Order
 

--- a/skills/vc-ship/references/workflow-phases.md
+++ b/skills/vc-ship/references/workflow-phases.md
@@ -8,7 +8,7 @@ This document provides detailed instructions for each phase of the vc-ship skill
 
 Detects protected branches (main/master/develop/production/staging), blocks the workflow if uncommitted changes exist on them, and offers to create a feature branch. Skips if already on a feature branch.
 
-See **[phase-0-protocol.md](phase-0-protocol.md)** for the full detection and migration protocol.
+See **[phase-0-protocol.md](phase-0-protocol.md#detection-order)** for the full detection and migration protocol.
 
 ## Phase 1: Repository Analysis
 
@@ -99,7 +99,7 @@ See **[phase-0-protocol.md](phase-0-protocol.md)** for the full detection and mi
 
 **Commit Message Format**:
 
-For detailed formatting rules, examples, and templates, see [commit-format.md](commit-format.md). Key rules:
+For detailed formatting rules, examples, and templates, see [commit-format.md](commit-format.md#summary-line). Key rules:
 
 - **Imperative mood**: "Add feature" not "Added feature"
 - **Be specific**: "Fix null pointer in login" not "Fix bug"
@@ -143,7 +143,7 @@ Bad examples:
 
 **Important**: NEVER use `git rebase -i` - it requires interactive input. Instead, explain to the user what commands they need to run manually, or use non-interactive git commands to achieve the same result (like `git reset --soft` followed by recommitting).
 
-**For detailed rebase safety guidelines, commands, and examples, see [rebase-guide.md](rebase-guide.md).**
+**For detailed rebase safety guidelines, commands, and examples, see [rebase-guide.md](rebase-guide.md#safety-checklist).**
 
 ## Phase 5: Pre-Push Quality Review (Mandatory)
 
@@ -151,7 +151,7 @@ Bad examples:
 
 This mandatory phase runs after commits are created (Phase 3) or cleaned up (Phase 4). It generates a push preview, runs three quality checks (generic message detection, squash opportunity detection, format compliance), detects available test commands, and presents a quality report. Users can fix issues, run tests, override with justification, or cancel.
 
-See **[phase-5-protocol.md](phase-5-protocol.md)** for complete quality check algorithms, test detection patterns, and user interaction flows.
+See **[phase-5-protocol.md](phase-5-protocol.md#three-quality-checks)** for complete quality check algorithms, test detection patterns, and user interaction flows.
 
 ## Phase 6: Push with Confirmation
 
@@ -159,7 +159,7 @@ See **[phase-5-protocol.md](phase-5-protocol.md)** for complete quality check al
 
 Checks for detached HEAD, fetches latest remote state, detects protected branches, and blocks pushes to them. For non-protected branches, shows a commit summary, asks for confirmation, and pushes (with `-u` for new branches). Force pushes to protected branches are absolutely blocked with no override.
 
-See **[protected-branch-protocol.md](protected-branch-protocol.md)** for the full protected branch push protocol.
+See **[protected-branch-protocol.md](protected-branch-protocol.md#detection-order)** for the full protected branch push protocol.
 
 ## Phase 7: Pull Request Creation (Optional)
 


### PR DESCRIPTION
## Summary

Restores `#anchor` fragments to markdown links across 11 skills (14 files). The skill-validator previously rejected anchors, so they were stripped. The validator is now fixed — anchors point readers to specific headings in reference files rather than landing at the top of each document.

## Changes

- **SKILL.md files** (9): tdd-cycle, vc-ship, refactor-clean, tech-debt, skill-quality, skill-improve, cc-check, claude-md-improver, claude-automation-recommender
- **Reference files** (5): tdd-cycle/phase-discipline.md, cc-lint/evaluation-process.md, vc-ship/workflow-phases.md, vc-ship/phase-0-protocol.md, vc-ship/protected-branch-protocol.md
- Pure link replacements — no content, structure, or formatting changes

## Testing

- All 9 modified skills pass `skill-validator check`
- +54/-54 lines — every change is a targeted anchor insertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)