### PR TITLE
fix: remove residual allowed-tools references

### DIFF
--- a/skills/cc-automation-recommender/references/skills-reference.md
+++ b/skills/cc-automation-recommender/references/skills-reference.md
@@ -86,7 +86,6 @@ name: skill-name
 description: What this skill does and when to use it
 disable-model-invocation: true  # Only user can invoke (for side effects)
 user-invocable: false           # Only Claude can invoke (for background knowledge)
-allowed-tools: Read Grep Glob   # Restrict tool access
 context: fork                   # Run in isolated subagent
 agent: Explore                  # Which agent type when forked
 ---
@@ -173,7 +172,6 @@ Generate and validate migrations using a bundled script:
 name: create-migration
 description: Create a database migration file
 disable-model-invocation: true
-allowed-tools: Read Write Bash
 ---
 
 Create a migration for: $ARGUMENTS

--- a/skills/skill-quality/references/quality-dimensions.md
+++ b/skills/skill-quality/references/quality-dimensions.md
@@ -143,7 +143,7 @@ description: Git workflow automation tool.
 **What to evaluate**:
 
 - Does frontmatter use only spec-standard fields (`name`, `description`)?
-- Are agent-specific extensions (e.g., `allowed-tools`, `model`, `context`) absent or clearly documented as implementation-specific?
+- Are agent-specific extensions (e.g., `model`, `context`) absent or clearly documented as implementation-specific?
 - Is the markdown structure standard (no proprietary directives)?
 - Could the skill's content work conceptually in another agent?
 
@@ -152,7 +152,6 @@ description: Git workflow automation tool.
 | Category       | Examples                                       | Status                     |
 | -------------- | ---------------------------------------------- | -------------------------- |
 | Spec-standard  | `name`, `description`                          | Required by agentskills.io |
-| Experimental   | `allowed-tools`                                | Varying agent support      |
 | Agent-specific | `model`, `context`, `disable-model-invocation` | Implementation-dependent   |
 
 **Red flags**:


### PR DESCRIPTION
## Summary

- Remove `allowed-tools` from skill-quality portability dimension examples and category table
- Remove `allowed-tools` from cc-automation-recommender frontmatter reference and example skill

Follow-up to PR #217. The only remaining `allowed-tools` mentions are in skill-improve's before/after anti-pattern example, which is intentional.

## Test plan

- [x] `grep -r "allowed-tools" skills/` — only skill-improve anti-pattern example remains
- [x] Prettier passes on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)