### PR TITLE
fix: clean up hooks from cc-lint findings

### DIFF
--- a/hooks/auto-format.sh
+++ b/hooks/auto-format.sh
@@ -10,8 +10,12 @@ file_path="${TOOL_FILE_PATH:-}"
 
 if [ -z "$file_path" ]; then
 	# Fallback: read from stdin JSON (PostToolUse payload structure)
-	if ! file_path=$(jq -r '.tool_input.file_path // empty' 2>/dev/null); then
-		exit 0 # Graceful exit if JSON parsing fails
+	if command -v jq &>/dev/null; then
+		if ! file_path=$(jq -r '.tool_input.file_path // empty' 2>/dev/null); then
+			exit 0 # Graceful exit if JSON parsing fails
+		fi
+	else
+		exit 0 # No jq available, can't parse stdin
 	fi
 fi
 

--- a/hooks/log-git-commands.sh
+++ b/hooks/log-git-commands.sh
@@ -4,14 +4,14 @@
 # Note: Intentionally no 'set -euo pipefail' - hooks must always exit 0
 
 input=$(cat)
-command=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
-description=$(echo "$input" | jq -r '.tool_input.description // "No description"' 2>/dev/null || echo "No description")
+command=$(jq -r '.tool_input.command // empty' 2>/dev/null <<<"$input" || echo "")
+description=$(jq -r '.tool_input.description // "No description"' 2>/dev/null <<<"$input" || echo "No description")
 
 # Only log git/gh/dot commands
-if echo "$command" | grep -qE '^(git|gh|dot)\s'; then
+if grep -qE '^(git|gh|dot)\s' <<<"$command"; then
 	timestamp=$(date '+%Y-%m-%d %H:%M:%S')
 	# Extract session ID from stdin JSON (last 8 chars)
-	session_id=$(echo "$input" | jq -r '.session_id // empty' 2>/dev/null)
+	session_id=$(jq -r '.session_id // empty' 2>/dev/null <<<"$input")
 	session_id="${session_id: -8}"
 	session_id="${session_id//[^a-zA-Z0-9]/_}"
 	session_id="${session_id:-default}"

--- a/hooks/log-hook-event.sh
+++ b/hooks/log-hook-event.sh
@@ -10,7 +10,7 @@ tool=""
 tool_input=""
 
 # Extract session ID from stdin JSON (last 8 chars)
-session_id=$(echo "$input" | jq -r '.session_id // empty' 2>/dev/null)
+session_id=$(jq -r '.session_id // empty' 2>/dev/null <<<"$input")
 session_id="${session_id: -8}"
 session_id="${session_id//[^a-zA-Z0-9]/_}"
 session_id="${session_id:-default}"
@@ -18,8 +18,8 @@ log_dir=~/.claude/logs/"$session_id"
 mkdir -p "$log_dir"
 
 if [ -n "$input" ]; then
-	tool=$(echo "$input" | jq -r '.tool // .tool_name // empty' 2>/dev/null)
-	tool_input=$(echo "$input" | jq -c '.tool_input // empty' 2>/dev/null)
+	tool=$(jq -r '.tool // .tool_name // empty' 2>/dev/null <<<"$input")
+	tool_input=$(jq -c '.tool_input // empty' 2>/dev/null <<<"$input")
 fi
 
 line="[$timestamp] $event_name"

--- a/hooks/validate-config.py
+++ b/hooks/validate-config.py
@@ -16,9 +16,6 @@ import yaml
 # Extension-specific validation rules
 AGENT_REQUIRED_FIELDS = ["name", "description"]
 SKILL_REQUIRED_FIELDS = ["name", "description"]
-OUTPUT_STYLE_REQUIRED_FIELDS = ["name", "description"]
-
-VALID_MODELS = ["sonnet", "opus", "haiku"]
 
 
 def extract_frontmatter(content):
@@ -40,13 +37,6 @@ def validate_agent(frontmatter, file_path):
     for field in AGENT_REQUIRED_FIELDS:
         if field not in frontmatter:
             errors.append(f"Missing required field: {field}")
-
-    # Validate model field
-    if "model" in frontmatter:
-        if frontmatter["model"] not in VALID_MODELS:
-            errors.append(
-                f"Invalid model: '{frontmatter['model']}'. Must be one of: {', '.join(VALID_MODELS)}"
-            )
 
     # Check name matches filename
     filename = os.path.splitext(os.path.basename(file_path))[0]
@@ -79,18 +69,6 @@ def validate_skill(frontmatter, file_path):
     return errors
 
 
-def validate_output_style(frontmatter):
-    """Validate output-style frontmatter."""
-    errors = []
-
-    # Check required fields
-    for field in OUTPUT_STYLE_REQUIRED_FIELDS:
-        if field not in frontmatter:
-            errors.append(f"Missing required field: {field}")
-
-    return errors
-
-
 try:
     data = json.load(sys.stdin)
 
@@ -114,8 +92,6 @@ try:
         file_type = "agent"
     elif "/skills/" in file_path and "SKILL.md" in file_path:
         file_type = "skill"
-    elif "/output-styles/" in file_path:
-        file_type = "output-style"
     else:
         # Don't validate other files (commands, references/, skill references/, README, etc.)
         sys.exit(0)
@@ -151,9 +127,6 @@ try:
                 "description: Comprehensive description including when to use (50+ chars)",
                 file=sys.stderr,
             )
-        elif file_type == "output-style":
-            print("name: Style Name", file=sys.stderr)
-            print("description: Brief persona description", file=sys.stderr)
         print("---", file=sys.stderr)
         sys.exit(2)
 
@@ -171,9 +144,6 @@ try:
         errors = validate_agent(frontmatter, file_path)
     elif file_type == "skill":
         errors = validate_skill(frontmatter, file_path)
-    elif file_type == "output-style":
-        errors = validate_output_style(frontmatter)
-
     if errors:
         print(
             f"Validation errors in {file_type} '{os.path.basename(file_path)}':",


### PR DESCRIPTION
## Summary

- Add `command -v jq` guard in `auto-format.sh` stdin fallback path
- Remove stale `VALID_MODELS` list and unreachable `output-style` validation from `validate-config.py`
- Replace `echo | jq` pipes with here-strings in `log-git-commands.sh` and `log-hook-event.sh`

## Test plan

- [ ] Verify auto-format hook still formats files on Edit/Write
- [ ] Verify validate-config hook still blocks invalid agent/skill frontmatter
- [ ] Verify git command logging still captures git/gh/dot commands
- [ ] Verify hook event logging still records lifecycle events

🤖 Generated with [Claude Code](https://claude.com/claude-code)