### PR TITLE
fix: improve cc-lint skill from quality review findings

### DIFF
--- a/skills/cc-lint/SKILL.md
+++ b/skills/cc-lint/SKILL.md
@@ -4,7 +4,8 @@ description: >-
   Quick structural validation of Claude Code customizations — checks YAML
   syntax, required fields, naming conventions, file organization, spec
   conformance, and settings.json health. Use for fast correctness checks,
-  linting, validating component structure, or checking portability.
+  linting, validating component structure, checking portability, or
+  reviewing a skill, agent, hook, or command for issues.
 ---
 
 ## Reference Files
@@ -51,6 +52,6 @@ This skill uses read-only tools for analysis:
 - **Read** - Examine file contents
 - **Grep** - Search for patterns across files
 - **Glob** - Find files by pattern
-- **Bash** - Execute read-only commands (ls, cat, head, tail, git log, etc.)
+- **Bash** - Execute read-only commands (ls, wc, stat, git log, etc.)
 
-No files are modified during evaluation. Reports can be saved to `~/.claude/logs/evaluations/` by the invoking command or skill.
+No files are modified during evaluation.

--- a/skills/cc-lint/evaluation-process.md
+++ b/skills/cc-lint/evaluation-process.md
@@ -63,8 +63,7 @@ Use Read to examine `~/.claude/settings.json`:
 
 1. Verify hooks are registered if needed
 2. Check for permission conflicts
-3. Verify spec-standard frontmatter fields
-4. Look for orphaned hook references
+3. Look for orphaned hook references
 
 ## Step 4: Assess Context Economy
 
@@ -77,12 +76,11 @@ Calculate approximate size and efficiency:
 
 ## Step 5: Assess Portability
 
-For skills, check spec conformance:
+For skills, confirm spec-standard frontmatter (verified in Step 2) and assess broader portability:
 
-1. Verify frontmatter uses only spec-standard fields (`name`, `description`)
-2. Check for agent-specific extensions in frontmatter or body
-3. Assess whether content is portable across agent implementations
-4. Note any non-standard fields as implementation-specific
+1. Check for agent-specific extensions in frontmatter or body
+2. Assess whether content is portable across agent implementations
+3. Note any non-standard fields as implementation-specific
 
 ## Step 6: Generate Structured Report
 

--- a/skills/cc-lint/examples.md
+++ b/skills/cc-lint/examples.md
@@ -227,3 +227,48 @@ if ".md" in path:
 - No stderr messages explaining failures
 - Missing try/except to prevent blocking user
 - Incomplete validation logic
+
+## Good Output-Style Example
+
+```markdown
+---
+name: concise-engineer
+description: Terse, technical communication style for experienced developers. Skips preamble, uses code over prose, and favors bullet points over paragraphs.
+---
+
+## Persona
+
+Senior engineer in code review mode. Direct, precise, no filler.
+
+## Tone
+
+- Declarative statements over hedging
+- Code snippets preferred over descriptions
+- Bullet points over paragraphs
+- Skip "Sure!" / "Great question!" preamble
+```
+
+**Assessment**: PASS
+
+- Clear, specific description with use case context
+- Well-defined persona in one sentence
+- Concrete tone guidelines with examples of what to do
+- Appropriate scope — guides style without over-constraining
+
+## Poor Output-Style Example
+
+```markdown
+---
+name: friendly
+description: Be friendly
+---
+
+Be nice and friendly to the user. Use a warm tone. Make them feel welcome.
+```
+
+**Issues**:
+
+- Description too short (<50 chars) and vague
+- No structured persona definition
+- No specific tone guidelines (what does "warm" mean in practice?)
+- Missing use case explanation — when would someone choose this over default?


### PR DESCRIPTION
## Summary

- Replace discouraged cat/head/tail Bash examples with wc/stat alternatives
- Remove contradictory report-saving mention
- Add natural-language trigger phrases to description
- Deduplicate spec-standard frontmatter check in evaluation process
- Add missing output-style good/poor examples

## Test plan

- [ ] Run `/cc-lint` against a skill and verify output
- [ ] Confirm SKILL.md passes its own structural validation
- [ ] Review examples.md for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)