### PR TITLE
fix: use third-person voice in skill descriptions

### DIFF
--- a/skills/cc-automation-recommender/SKILL.md
+++ b/skills/cc-automation-recommender/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-automation-recommender
-description: Analyze a codebase and recommend Claude Code automations (hooks, subagents, skills, plugins, MCP servers). Use when user asks for automation recommendations, wants to optimize their Claude Code setup, mentions improving Claude Code workflows, asks how to first set up Claude Code for a project, wants to know what Claude Code features they should use, asks about Claude Code best practices, or wants to know what tools to install for Claude Code.
+description: Analyzes a codebase and recommends Claude Code automations (hooks, subagents, skills, plugins, MCP servers). Use when user asks for automation recommendations, wants to optimize their Claude Code setup, mentions improving Claude Code workflows, asks how to first set up Claude Code for a project, wants to know what Claude Code features they should use, asks about Claude Code best practices, or wants to know what tools to install for Claude Code.
 ---
 
 **This skill is read-only.** It analyzes the codebase and outputs recommendations. It does NOT create or modify any files. Users implement the recommendations themselves or ask Claude separately to help build them.

--- a/skills/go-quality-gate/SKILL.md
+++ b/skills/go-quality-gate/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: go-quality-gate
+description: Runs Go code quality checks — formatting, static analysis, and tests. Use when checking Go code quality, linting Go code, running Go checks, validating Go code, go quality gate, check my Go project, or run go lint.
+---
+
+# Go Quality Gate
+
+Run a standardized set of Go quality checks. Auto-fix what's fixable, report the rest with specific locations.
+
+## Prerequisites
+
+Verify these tools are available before running checks. If missing, suggest installation.
+
+- `gofumpt` — stricter gofmt (`go install mvdan.cc/gofumpt@latest`)
+- `golangci-lint` — meta-linter (`go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`)
+
+## Check Sequence
+
+Run checks in this order. Each phase builds on the previous — formatting first so later tools analyze clean code.
+
+### 1. Format (auto-fix)
+
+Run `gofumpt -extra -w .` — report which files were modified. If no files changed, report "formatting clean."
+
+### 2. Go fix (auto-fix)
+
+Run `go fix ./...` — apply automated fixes for API changes. Report any fixes applied.
+
+### 3. Go vet (report)
+
+Run `go vet ./...` — report issues with file, line, and message. Do not attempt to auto-fix vet findings without user confirmation, as they often involve subtle correctness issues.
+
+### 4. Build (report)
+
+Run `go build ./...` — verify the project compiles. If this fails, report errors and stop — test and lint results are unreliable against code that doesn't build.
+
+### 5. Test (report)
+
+Run `go test -race -count=1 ./...` — race detector enabled, `-count=1` disables test caching for a fresh run. Report pass/fail per package.
+
+### 6. Lint (report)
+
+Run `golangci-lint run ./...` — if a `.golangci.yml` exists, it's picked up automatically. Report issues grouped by linter with file and line.
+
+## Output
+
+After all checks complete, present a summary table:
+
+```text
+| Check          | Status | Details           |
+|----------------|--------|-------------------|
+| gofumpt        | FIXED  | 3 files formatted |
+| go fix         | CLEAN  |                   |
+| go vet         | PASS   |                   |
+| go build       | PASS   |                   |
+| go test        | FAIL   | 2/15 packages     |
+| golangci-lint  | WARN   | 4 issues          |
+```
+
+Then list specific issues grouped by file, with line numbers. Offer to fix reported issues if the user wants.

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: skill-creator
+description: Creates new Claude Code skills from scratch or from conversation context. Use when users want to make a skill, create a skill, turn this into a skill, build a new customization, capture a workflow as a reusable skill, write a skill, design a skill, generate a skill, or draft a new skill.
+---
+
+# Skill Creator
+
+Create new Claude Code skills. Walk the user from intent through a finished SKILL.md.
+
+## Communicating with the user
+
+Adapt to the user's technical level. If they're comfortable with YAML frontmatter and kebab-case naming, match that. If not, explain terms briefly when first used.
+
+## Creating a skill
+
+### 1. Capture Intent
+
+Start by understanding the user's intent. The current conversation might already contain a workflow the user wants to capture (e.g., "turn this into a skill"). If so, extract answers from the conversation history first — the tools used, the sequence of steps, corrections the user made, input/output formats observed. The user may need to fill gaps, and should confirm before proceeding.
+
+1. What should this skill enable the agent to do?
+2. When should this skill trigger? (what user phrases/contexts)
+3. What's the expected output format?
+
+### 2. Interview and Research
+
+Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Come prepared with context to reduce burden on the user.
+
+Check available MCPs — if useful for research (searching docs, finding similar skills, looking up best practices), research in parallel via subagents if available, otherwise inline.
+
+### 3. Write the SKILL.md
+
+Based on the user interview, write a complete SKILL.md with these components:
+
+#### Frontmatter (required)
+
+- **name**: Skill identifier — kebab-case, lowercase letters/digits/hyphens only, no leading/trailing/consecutive hyphens, max 64 characters. The directory name must match this value.
+- **description**: When to trigger and what it does. This is the primary triggering mechanism — include both what the skill does AND specific phrases/contexts for when to use it. Max 1024 characters, no angle brackets.
+- Optional fields: `license` (SPDX identifier), `compatibility` (runtime requirements), `allowed-tools` (restrict tool access), `metadata` (arbitrary key-value pairs)
+
+#### Body
+
+The markdown instructions that tell the agent how to execute the skill. Structure with clear sections, imperative instructions, and concrete examples.
+
+**Writing patterns:**
+
+Define output formats with exact templates:
+
+```markdown
+## Report structure
+
+Use this exact template for every report:
+
+# [Title]
+
+## Executive summary
+
+## Key findings
+
+## Recommendations
+```
+
+Use input/output examples to show expected behavior:
+
+```markdown
+## Commit message format
+
+**Example 1:**
+Input: Added user authentication with JWT tokens
+Output: feat(auth): implement JWT-based authentication
+```
+
+#### Writing principles
+
+- **Concise is key.** The context window is a public good. The agent is already very smart — only add context it does not already have. Challenge each piece of information: "Does this paragraph justify its token cost?" Prefer concise examples over verbose explanations.
+- **Set appropriate degrees of freedom.** Match specificity to the task's fragility. Narrow bridge with cliffs needs specific guardrails (low freedom); open field allows many routes (high freedom). Use text instructions for high freedom, pseudocode for medium, specific scripts for low.
+- **Explain why, not just what.** LLMs respond better to understanding than rigid directives. If you find yourself writing ALWAYS or NEVER in all caps, reframe and explain the reasoning instead.
+- **What not to include.** Do not create README.md, CHANGELOG.md, or other auxiliary documentation files. The skill should only contain information needed for an AI agent to do the job — no setup procedures, user-facing docs, or process notes about how the skill was created.
+
+### 4. Deliver
+
+Write the SKILL.md into the target directory (`<skill-name>/SKILL.md`). That's the deliverable — a single file in a named directory. If the user wants revisions, iterate on the file in place.

--- a/skills/skill-improve/SKILL.md
+++ b/skills/skill-improve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-improve
-description: Generate prioritized improvement recommendations for Claude Code skills. Use when improving skills, getting skill suggestions, enhancing customizations, or wanting actionable feedback on how to make a skill better. Provides impact/effort prioritization.
+description: Generates prioritized improvement recommendations for Claude Code skills. Use when improving skills, getting skill suggestions, enhancing customizations, or wanting actionable feedback on how to make a skill better. Provides impact/effort prioritization.
 ---
 
 ## Reference Files

--- a/skills/skill-quality/SKILL.md
+++ b/skills/skill-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-quality
-description: Rate Claude Code skills with numerical scores (1-5) across 6 quality dimensions. Use when evaluating skill quality, scoring skills, rating customizations, or comparing skill effectiveness. Provides weighted scores and quality tier assessment.
+description: Rates Claude Code skills with numerical scores (1-5) across 6 quality dimensions. Use when evaluating skill quality, scoring skills, rating customizations, or comparing skill effectiveness. Provides weighted scores and quality tier assessment.
 ---
 
 ## Reference Files

--- a/skills/tdd-cycle/SKILL.md
+++ b/skills/tdd-cycle/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tdd-cycle
 description: >-
-  Enforce strict red-green-refactor TDD cycles with phase gates. Use when
+  Enforces strict red-green-refactor TDD cycles with phase gates. Use when
   doing TDD, test-driven development, red green refactor, write tests first,
   test-first development, failing test, or make tests pass.
 ---

--- a/skills/tech-debt/SKILL.md
+++ b/skills/tech-debt/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: tech-debt
 description: >-
-  Identify, classify, and prioritize technical debt with a remediation roadmap.
-  Use when auditing technical debt, assessing code quality, analyzing maintenance
-  burden, inventorying legacy code, or asking what's slowing us down.
+  Identifies, classifies, and prioritizes technical debt with a remediation
+  roadmap. Use when auditing technical debt, assessing code quality, analyzing
+  maintenance burden, inventorying legacy code, or asking what's slowing us down.
 ---
 
 # Technical Debt Analysis


### PR DESCRIPTION
## Summary

- Align 7 skill descriptions with Anthropic best practices by changing imperative voice to third-person declarative voice
- Affected skills: cc-automation-recommender, go-quality-gate, skill-creator, skill-improve, skill-quality, tdd-cycle, tech-debt
- Also adds go-quality-gate and skill-creator as new tracked skills

## Test plan

- [ ] Verify all 7 SKILL.md files have third-person descriptions
- [ ] Run `/cc-lint` on modified skills
- [ ] Confirm skills are detected correctly by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)