### PR TITLE
docs: encode Anthropic skill best practices in conventions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -26,7 +26,10 @@ See `references/decision-matrix.md` for when to use each component type.
 - SKILL.md target: under 500 lines; use reference files in the same directory for depth (progressive disclosure)
 - Required frontmatter: `name`, `description` (with trigger phrases)
 - Name must be kebab-case, match the directory name, max 64 chars
+- Description must use **third-person voice** ("Analyzes...", not "Analyze...")
 - Description should include **what** it does and **when** to use it (200-500 chars)
+- Reference files exceeding 100 lines should include a `## Contents` TOC
+- Naming uses `cc-`/`vc-` prefix conventions per `naming-conventions.md` (diverges from Anthropic's gerund suggestion by design)
 
 ### Hooks
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive, production-ready configuration for [Claude Code](https://claude
 
 ## What's Here
 
-- **14 Skills** — Reusable capabilities for auditing, authoring, workflows, and more
+- **16 Skills** — Reusable capabilities for auditing, authoring, workflows, and more
 - **11 Hooks** — Automation for validation, formatting, logging, and notifications
 - **8 Rules** — Language and tool-specific coding standards
 - **2 Commands** — Quick shortcuts for common operations

--- a/references/frontmatter-requirements.md
+++ b/references/frontmatter-requirements.md
@@ -109,11 +109,22 @@ description: What and when to use # Required: max 1024 chars
 
 ### Description Best Practices
 
+- **Use third-person voice** — descriptions must start with a third-person verb ("Analyzes...", "Generates...", "Runs..."), not imperative ("Analyze...", "Generate...", "Run...")
 - Include **what** the skill provides
 - Include **when** to use it (trigger scenarios)
 - Use trigger phrases that match user queries
 - Target 200-500 characters for good discoverability
 - Front-load important keywords
+
+**Examples**:
+
+```yaml
+# ✅ Third-person voice
+description: Analyzes a codebase and recommends Claude Code automations...
+
+# ❌ Imperative voice
+description: Analyze a codebase and recommend Claude Code automations...
+```
 
 ### Example
 

--- a/references/naming-conventions.md
+++ b/references/naming-conventions.md
@@ -294,6 +294,18 @@ For each renamed skill:
 
 ---
 
+## Divergence from Anthropic Docs
+
+The [official Anthropic skill authoring best practices](https://docs.anthropic.com/en/docs/agents-and-tools/agent-skills/best-practices) suggest gerund-style naming (e.g., `processing-pdfs`). This repository diverges intentionally:
+
+- **Established prefix conventions**: `cc-` (Claude Code meta), `vc-` (version control) provide categorical namespacing
+- **Suffix taxonomy**: The 7-pattern suffix system above (`-review`, `-guide`, `-workflow`, etc.) communicates function type more precisely than gerunds
+- **Capability-first naming**: `code-review` over `reviewing-code` — nouns describe what the skill does, not how it's invoked
+
+This divergence is documented and deliberate. The Anthropic docs list gerund naming as a suggestion with acceptable alternatives.
+
+---
+
 **Next Steps**:
 
 - Ready to implement? See [Frontmatter Requirements](frontmatter-requirements.md) for YAML specs

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -34,7 +34,7 @@ Based on the user interview, write a complete SKILL.md with these components:
 #### Frontmatter (required)
 
 - **name**: Skill identifier — kebab-case, lowercase letters/digits/hyphens only, no leading/trailing/consecutive hyphens, max 64 characters. The directory name must match this value.
-- **description**: When to trigger and what it does. This is the primary triggering mechanism — include both what the skill does AND specific phrases/contexts for when to use it. Max 1024 characters, no angle brackets.
+- **description**: When to trigger and what it does. Must use **third-person voice** ("Analyzes...", "Generates...", not "Analyze...", "Generate..."). This is the primary triggering mechanism — include both what the skill does AND specific phrases/contexts for when to use it. Max 1024 characters, no angle brackets.
 - Optional fields: `license` (SPDX identifier), `compatibility` (runtime requirements), `allowed-tools` (restrict tool access), `metadata` (arbitrary key-value pairs)
 
 #### Body


### PR DESCRIPTION
## Summary

- Add third-person voice rule to CLAUDE.md skills conventions, frontmatter-requirements.md, and skill-creator's frontmatter guidance
- Document naming divergence rationale in naming-conventions.md (we use cc-/vc- prefixes + suffix taxonomy instead of Anthropic's gerund suggestion)
- Update README skill count from 14 to 16

**Base**: `fix/skill-description-voice` (PR #224)

## Test plan

- [ ] `bunx prettier --check` passes on all modified files
- [ ] Third-person voice rule is documented in 3 locations
- [ ] Naming divergence rationale is clear and linked to existing conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)