### PR TITLE
docs: add table of contents to reference files >100 lines

### DIFF
--- a/references/decision-matrix.md
+++ b/references/decision-matrix.md
@@ -7,6 +7,13 @@ Quick reference for choosing the right component type. For detailed scenarios, m
 - [Naming Conventions](naming-conventions.md) - Naming patterns for all components
 - [Frontmatter Requirements](frontmatter-requirements.md) - YAML specification
 
+## Contents
+
+- Decision Matrix: Claude Code Component Selection
+  - When to Use Each Component
+  - Decision Flow
+  - Key Distinctions
+
 ## Decision Matrix: Claude Code Component Selection
 
 | **Criterion**     | **Skill**                              | **Subagent**                | **Command**             | **Output Style**             | **Hook**                 |

--- a/references/frontmatter-requirements.md
+++ b/references/frontmatter-requirements.md
@@ -8,6 +8,17 @@ Complete YAML frontmatter specifications for all Claude Code component types.
 - Quick comparison table? See [Decision Matrix](decision-matrix.md)
 - Need naming patterns? See [Naming Conventions](naming-conventions.md)
 
+## Contents
+
+- Subagents
+- Skills
+  - Description Best Practices
+- Hooks (No Frontmatter)
+- Output Styles (Deprecated)
+- Validation Checklist
+- Common Frontmatter Errors
+- Tools for Validation
+
 ## Subagents
 
 ```yaml

--- a/references/hook-events.md
+++ b/references/hook-events.md
@@ -2,6 +2,17 @@
 
 Comprehensive guide to Claude Code hook events and configuration.
 
+## Contents
+
+- Hook Types
+- Agent-Level Hooks
+- Configuration Pattern
+- Environment Variables
+- Matchers
+- Hook Script Requirements
+- Performance Considerations
+- Common Patterns
+
 ## Hook Types
 
 | Event               | Trigger                 | Tool Context | Use Cases                          |

--- a/references/naming-conventions.md
+++ b/references/naming-conventions.md
@@ -8,6 +8,20 @@ Consistent naming patterns for Claude Code subagents, skills, and hooks to impro
 - [When to Use What](when-to-use-what.md) - Decision guide for choosing component types
 - [Decision Matrix](decision-matrix.md) - Quick comparison table
 
+## Contents
+
+- Core Principles
+- Subagents
+- Agent Skills
+  - Skill Suffix Patterns
+  - Suffix Decision Matrix
+  - Common Naming Mistakes
+  - Guidelines
+  - Migration Guide
+- Hooks
+- File Naming Quick Reference
+- Divergence from Anthropic Docs
+
 ## Core Principles
 
 1. **Kebab-case for files**: All files use lowercase with hyphens (`my-component.md`)

--- a/references/when-to-use-what.md
+++ b/references/when-to-use-what.md
@@ -9,6 +9,18 @@ Decision guide for choosing the right Claude Code customization type for your us
 - [Naming Conventions](naming-conventions.md) - Naming patterns for all components
 - [Frontmatter Requirements](frontmatter-requirements.md) - YAML specification
 
+## Contents
+
+- Decision Matrix
+- Use an Agent when
+- Use a Skill when
+- Use an Output-Style when
+- Use a Hook when
+- Decision Flow
+- Common Scenarios
+- Migration Paths
+- Quick Reference
+
 ---
 
 ## Decision Matrix

--- a/skills/cc-automation-recommender/mcp-servers.md
+++ b/skills/cc-automation-recommender/mcp-servers.md
@@ -4,6 +4,21 @@ MCP (Model Context Protocol) servers extend Claude's capabilities by connecting 
 
 **Note**: These are common MCP servers. Use web search to find MCP servers specific to the codebase's services and integrations.
 
+## Contents
+
+- Setup & Team Sharing
+- Documentation & Knowledge
+- Browser & Frontend
+- Databases
+- Version Control & DevOps
+- Cloud Infrastructure
+- Monitoring & Observability
+- Communication
+- File & Data
+- Containers & DevOps
+- AI & ML
+- Quick Reference: Detection Patterns
+
 ## Setup & Team Sharing
 
 **Connection methods:**

--- a/skills/cc-automation-recommender/skills-reference.md
+++ b/skills/cc-automation-recommender/skills-reference.md
@@ -6,6 +6,15 @@ Some pre-built skills are available through official plugins (install via `/plug
 
 **Note**: These are common patterns. Use web search to find skill ideas specific to the codebase's tools and frameworks.
 
+## Contents
+
+- Available from Official Plugins
+- Quick Reference: Official Plugin Skills
+- Custom Project Skills
+- Custom Skill Examples
+- Argument Patterns
+- Dynamic Context Injection
+
 ---
 
 ## Available from Official Plugins

--- a/skills/improve-instructions/examples.md
+++ b/skills/improve-instructions/examples.md
@@ -2,6 +2,15 @@
 
 Before/after examples of instruction improvements.
 
+## Contents
+
+- Example 1: Tool Preference
+- Example 2: Workflow Documentation
+- Example 3: Consolidating Scattered Guidance
+- Example 4: Clarifying Ambiguity
+- Example 5: Project-Specific Context
+- Example 6: Stopping a Repeated Mistake
+
 ## Example 1: Tool Preference
 
 **Observed pattern:**

--- a/skills/map-codebase/workflow.md
+++ b/skills/map-codebase/workflow.md
@@ -1,3 +1,17 @@
+## Contents
+
+- Purpose
+- Philosophy
+- Process
+  - Check Existing
+  - Create Structure
+  - Spawn Agents
+  - Collect Results
+  - Write Documents
+  - Verify Output
+  - Commit Codebase Map
+- Success Criteria
+
 ## Purpose
 
 Orchestrate parallel Explore agents to analyze codebase and produce structured documents in .planning/codebase/

--- a/skills/skill-improve/examples.md
+++ b/skills/skill-improve/examples.md
@@ -2,6 +2,17 @@
 
 This document shows before/after examples demonstrating improvements in action.
 
+## Contents
+
+- Example 1: Trigger Phrase Enhancement
+- Example 2: Progressive Disclosure
+- Example 3: Adding Missing Examples
+- Example 4: Fixing Inconsistent Terminology
+- Example 5: Portability Improvement
+- Example 6: Adding "When to Use" Guidance
+- Example 7: Comprehensive Improvement Report
+- Pattern Recognition
+
 ## Example 1: Trigger Phrase Enhancement
 
 ### Before

--- a/skills/tdd-cycle/phase-discipline.md
+++ b/skills/tdd-cycle/phase-discipline.md
@@ -2,6 +2,12 @@
 
 Rules, techniques, and validation gates for each TDD phase. Each phase must pass its gate before advancing.
 
+## Contents
+
+- RED Phase
+- GREEN Phase
+- REFACTOR Phase
+
 ## RED Phase
 
 **Core constraint:** No implementation code exists yet. Tests define what the code should do.

--- a/skills/tech-debt/debt-categories.md
+++ b/skills/tech-debt/debt-categories.md
@@ -2,6 +2,17 @@
 
 Taxonomy of technical debt types with detection criteria and measurement thresholds. Use this as a checklist when scanning a codebase.
 
+## Contents
+
+- Code Debt
+  - Duplication
+  - Complexity
+  - Poor Structure
+- Architecture Debt
+- Testing Debt
+- Documentation Debt
+- Infrastructure Debt
+
 ## Code Debt
 
 Structural problems within individual files and functions.

--- a/skills/tech-debt/roi-framework.md
+++ b/skills/tech-debt/roi-framework.md
@@ -2,6 +2,15 @@
 
 Impact assessment, risk classification, and prioritization for technical debt items. Use this to score and rank findings from the debt inventory.
 
+## Contents
+
+- Impact Dimensions
+- Risk Classification
+- Effort Estimation
+- Prioritization Tiers
+- Per-Item Metrics
+- Prevention Indicators
+
 ## Impact Dimensions
 
 Evaluate each debt item across three dimensions:

--- a/skills/vc-ship/eval-large-refactor.md
+++ b/skills/vc-ship/eval-large-refactor.md
@@ -1,5 +1,15 @@
 # Evaluation: Large Refactoring with Multiple Atomic Commits
 
+## Contents
+
+- Scenario Description
+- Initial Repository State
+- User Request
+- Expected Skill Behavior
+- Success Criteria
+- Common Pitfalls to Avoid
+- Optimal Commit Groupings
+
 ## Scenario Description
 
 User refactored the database layer to use a new ORM. Changes span multiple files and should be organized into logical atomic commits.


### PR DESCRIPTION
## Summary

- Add `## Contents` section to 14 reference files exceeding 100 lines
- Covers 5 files in `references/` and 9 files across `skills/` subdirectories
- Mechanical change: one concern (navigation), one commit

**Base**: `refactor/split-standalone-skills` (PR #226)

## Test plan

- [ ] `bunx prettier --check` passes on all modified files
- [ ] Each TOC accurately reflects the file's ## headings

🤖 Generated with [Claude Code](https://claude.com/claude-code)