### PR TITLE
docs: add showboat reference to walkthrough command

### DIFF
--- a/commands/walkthrough.md
+++ b/commands/walkthrough.md
@@ -1,1 +1,21 @@
-Read the source and then plan a linear walkthrough of the code that explains how it all works in detail. Then run “uvx showboat –help” to learn showboat. Use showboat to create a walkthrough.md file in the repo and build the walkthrough in there, using showboat note for commentary and showboat exec plus sed, grep, cat or whatever you need to include snippets of code you are talking about. Include any concerns we should have about the code and its adherence to community standards.
+Read the source and then plan a linear walkthrough of the code that explains how it all works in detail. Use showboat to create a `walkthrough.md` file in the repo and build the walkthrough in there, using `showboat note` for commentary and `showboat exec` plus `sed -n`, `grep`, `cat` or whatever you need to include snippets of code you are talking about. Include any concerns we should have about the code and its adherence to community standards.
+
+## Showboat reference
+
+Showboat creates executable markdown documents where every fenced code block is re-runnable and verifiable.
+
+### Commands
+
+- `uvx showboat init <file> <title>` — Create a new document
+- `uvx showboat note <file> [text]` — Append commentary (plain markdown, not executed). Use heredoc for multi-line: `uvx showboat note file.md <<'EOF' ... EOF`
+- `uvx showboat exec <file> <lang> [code]` — Run code, capture output. Appends a `lang` block (the command) and an `output` block (the result)
+- `uvx showboat pop <file>` — Remove the most recent entry (useful after a failed exec)
+- `uvx showboat verify <file>` — Re-run all code blocks and diff against captured output
+- `uvx showboat verify <file> --output <file>` — Re-run and update output blocks in place
+
+### Gotchas
+
+- **Every fenced block is executable.** Showboat treats all code blocks as runnable — there is no "display only" mode. Static content (trees, diagrams) must use a command that produces the output, e.g. `cat <<'HEREDOC' ... HEREDOC`
+- **Non-deterministic output breaks verify.** Timing, dates, and random values will differ across runs. Avoid capturing commands like `bun test` whose output includes wall-clock time. Use deterministic alternatives (e.g. `grep -c` to count tests)
+- **Code fences in output.** If the captured output contains triple backticks, showboat uses quadruple-backtick fences (``````) automatically — no special handling needed
+- **`walkthrough.md` is exempt from prettier** in the global auto-format hook. Showboat manages its own formatting; prettier would break verified output blocks

--- a/hooks/auto-format.sh
+++ b/hooks/auto-format.sh
@@ -32,6 +32,10 @@ case "$file_path" in
 	command -v prettier &>/dev/null && prettier --write "$file_path" 2>/dev/null
 	;;
 *.md)
+	basename=$(basename "$file_path")
+	if [ "$basename" = "walkthrough.md" ]; then
+		exit 0 # Managed by showboat — prettier would break verified output blocks
+	fi
 	command -v prettier &>/dev/null && prettier --write "$file_path" 2>/dev/null
 	;;
 esac


### PR DESCRIPTION
## Summary

- Add inline showboat command reference and gotchas section to walkthrough command so users don't need `--help` mid-session
- Add `walkthrough.md` basename exemption to auto-format hook — showboat manages its own formatting; prettier would break verified output blocks

## Test plan

- [x] `bunx prettier --check commands/walkthrough.md` passes
- [x] `shellcheck hooks/auto-format.sh` passes
- [x] Auto-format hook correctly skips files named `walkthrough.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)