### PR TITLE
fix: handle no-remote repos by skipping push/PR phases

### DIFF
--- a/skills/vc-ship/SKILL.md
+++ b/skills/vc-ship/SKILL.md
@@ -76,7 +76,7 @@ The skill follows an 8-phase workflow:
 | Large changeset (10+ files) | Suggest splitting into multiple PRs                                                                                     |
 | Detached HEAD               | Alert user, offer to create branch                                                                                      |
 | Merge conflicts             | STOP, show files, guide resolution                                                                                      |
-| No remote                   | Offer to add origin                                                                                                     |
+| No remote                   | Detect in Phase 1, complete through Phase 5, then end workflow (skip push/PR)                                           |
 | Protected branch            | BLOCK, require feature branch (see [phase-0-protocol.md](phase-0-protocol.md#scenario-1-uncommitted-changes--blocking)) |
 | Rebase in progress          | Alert, offer continue or abort                                                                                          |
 

--- a/skills/vc-ship/protected-branch-protocol.md
+++ b/skills/vc-ship/protected-branch-protocol.md
@@ -54,13 +54,13 @@ No override. Detect by checking if remote has commits we don't have (`git rev-li
 
 ## Edge Cases
 
-| Situation                    | Action                                               |
-| ---------------------------- | ---------------------------------------------------- |
-| Hotfix branch (`hotfix/*`)   | Allow push, require PR to main                       |
-| Release branch (`release/*`) | Allow push, suggest PR to main                       |
-| Some commits already pushed  | Warn about unusual state, migrate only new commits   |
-| Detached HEAD                | Offer to create branch first                         |
-| No remote                    | Offer to add remote, or proceed without verification |
+| Situation                    | Action                                             |
+| ---------------------------- | -------------------------------------------------- |
+| Hotfix branch (`hotfix/*`)   | Allow push, require PR to main                     |
+| Release branch (`release/*`) | Allow push, suggest PR to main                     |
+| Some commits already pushed  | Warn about unusual state, migrate only new commits |
+| Detached HEAD                | Offer to create branch first                       |
+| No remote                    | Skip Phase 6 entirely — commits stay local-only    |
 
 ## Rollback
 

--- a/skills/vc-ship/workflow-phases.md
+++ b/skills/vc-ship/workflow-phases.md
@@ -33,6 +33,7 @@ See **[phase-0-protocol.md](phase-0-protocol.md#detection-order)** for the full 
 - Check for merge conflict markers in diff output
 - Check for rebase in progress (look for `.git/rebase-merge` or `.git/rebase-apply`)
 - Alert user and stop if conflicts or rebase in progress
+- Check for remotes: `git remote`. If none exist, note this and continue through Phase 5 but skip Phases 6-7 (push/PR) at the end. Inform the user that commits are local-only.
 
 ## Phase 2: Organize into Atomic Commits
 
@@ -157,13 +158,17 @@ See **[phase-5-protocol.md](phase-5-protocol.md#three-quality-checks)** for comp
 
 **Goal**: Push commits to remote safely after user approval.
 
-Checks for detached HEAD, fetches latest remote state, detects protected branches, and blocks pushes to them. For non-protected branches, shows a commit summary, asks for confirmation, and pushes (with `-u` for new branches). Force pushes to protected branches are absolutely blocked with no override.
+**Skip this phase entirely if no remote was detected in Phase 1.** Inform the user that commits are local-only and the workflow is complete.
+
+Otherwise: checks for detached HEAD, fetches latest remote state, detects protected branches, and blocks pushes to them. For non-protected branches, shows a commit summary, asks for confirmation, and pushes (with `-u` for new branches). Force pushes to protected branches are absolutely blocked with no override.
 
 See **[protected-branch-protocol.md](protected-branch-protocol.md#detection-order)** for the full protected branch push protocol.
 
 ## Phase 7: Pull Request Creation (Optional)
 
 **Goal**: Optionally create a pull request after successful push.
+
+**Skip this phase entirely if no remote exists.** The workflow ends after Phase 5 (or Phase 6 if push was skipped due to no remote).
 
 **Steps**:
 


### PR DESCRIPTION
## Summary

- Instead of offering to add a remote when none exists, vc-ship now detects this in Phase 1 and completes through Phase 5 (quality review), then ends gracefully
- Commits stay local-only — Phases 6 (push) and 7 (PR) are skipped entirely
- Updated SKILL.md edge case table, workflow-phases.md, and protected-branch-protocol.md for consistency

## Test plan

- [ ] Verify vc-ship workflow in a repo with no remote configured
- [ ] Verify vc-ship workflow in a normal repo with remote still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)