### PR TITLE
docs: align validation skills with Agent Skills spec and AGENTS.md standard

### DIFF
--- a/references/README.md
+++ b/references/README.md
@@ -7,6 +7,8 @@ This directory contains documentation shared across all Claude Code customizatio
 ```text
 references/
 ├── README.md (this file)
+├── agent-skills-spec.md
+├── agents-md-standard.md
 ├── decision-matrix.md
 ├── frontmatter-requirements.md
 ├── hook-events.md
@@ -34,6 +36,21 @@ All files support creating and auditing Claude Code extensions (skills, agents, 
 - Common use cases and examples
 - Use when: Choosing which component type to create
 - Links to: decision-matrix.md, naming-conventions.md, frontmatter-requirements.md
+
+### External Standards
+
+**[agent-skills-spec.md](agent-skills-spec.md)**
+
+- Normative summary of the [agentskills.io specification](https://agentskills.io/specification)
+- Name validation rules, frontmatter field definitions (required + optional), progressive disclosure guidance
+- Single source of truth for spec conformance checks across skills
+- Referenced by: cc-lint, skill-quality, skill-creator, frontmatter-requirements.md
+
+**[agents-md-standard.md](agents-md-standard.md)**
+
+- Summary of the [AGENTS.md standard](https://agents.md/) and its relationship to CLAUDE.md
+- Placement, scoping, ecosystem compatibility (20+ agents)
+- Referenced by: cc-lint (portability checks), skill-quality (portability dimension)
 
 ### Implementation Specifications
 
@@ -144,5 +161,6 @@ When updating shared references:
 
 ---
 
-File count: 5 files (decision-matrix.md, frontmatter-requirements.md,
-hook-events.md, naming-conventions.md, when-to-use-what.md)
+File count: 7 files (agent-skills-spec.md, agents-md-standard.md,
+decision-matrix.md, frontmatter-requirements.md, hook-events.md,
+naming-conventions.md, when-to-use-what.md)

--- a/references/agent-skills-spec.md
+++ b/references/agent-skills-spec.md
@@ -1,0 +1,142 @@
+# Agent Skills Specification
+
+Normative summary of the [agentskills.io specification](https://agentskills.io/specification). This is the single source of truth for validation and quality checks across skills.
+
+## Contents
+
+- [Directory Structure](#directory-structure)
+- [Frontmatter Fields](#frontmatter-fields)
+- [Name Validation Rules](#name-validation-rules)
+- [Description Requirements](#description-requirements)
+- [Optional Fields](#optional-fields)
+- [Progressive Disclosure](#progressive-disclosure)
+- [File References](#file-references)
+
+## Directory Structure
+
+A skill is a directory containing at minimum a `SKILL.md` file:
+
+```text
+skill-name/
+├── SKILL.md          # Required
+├── scripts/          # Optional: executable code
+├── references/       # Optional: additional documentation
+└── assets/           # Optional: templates, images, data files
+```
+
+The directory name **must match** the `name` frontmatter field.
+
+## Frontmatter Fields
+
+### Required
+
+| Field         | Max Length | Constraints                                         |
+| ------------- | ---------- | --------------------------------------------------- |
+| `name`        | 64 chars   | See [Name Validation Rules](#name-validation-rules) |
+| `description` | 1024 chars | Non-empty. What it does AND when to use it.         |
+
+### Optional (spec-standard)
+
+| Field           | Max Length | Purpose                                               |
+| --------------- | ---------- | ----------------------------------------------------- |
+| `license`       | --         | License name or reference to bundled license file     |
+| `compatibility` | 500 chars  | Environment requirements (product, packages, etc.)    |
+| `metadata`      | --         | Arbitrary key-value map (string keys, string values)  |
+| `allowed-tools` | --         | Space-delimited pre-approved tool list (experimental) |
+
+**Any field not in the above tables is non-standard.** Non-standard fields reduce portability across agent implementations.
+
+## Name Validation Rules
+
+All of these must pass:
+
+1. **Length**: 1-64 characters
+2. **Characters**: Unicode lowercase alphanumeric and hyphens only (`a-z`, `0-9`, `-`)
+3. **No leading hyphen**: Must not start with `-`
+4. **No trailing hyphen**: Must not end with `-`
+5. **No consecutive hyphens**: Must not contain `--`
+6. **Directory match**: Must match the parent directory name exactly
+
+### Valid
+
+```yaml
+name: pdf-processing
+name: data-analysis
+name: code-review
+name: my-skill-v2
+```
+
+### Invalid
+
+```yaml
+name: PDF-Processing    # uppercase
+name: -pdf              # leading hyphen
+name: pdf-              # trailing hyphen
+name: pdf--processing   # consecutive hyphens
+name: my_skill          # underscores
+name: My Skill          # spaces and uppercase
+```
+
+## Description Requirements
+
+- **Min**: 1 character (non-empty)
+- **Max**: 1024 characters
+- **Content**: Should describe both what the skill does and when to use it
+- **Keywords**: Should include specific terms that help agents identify relevant tasks
+- **Quality target**: 200-500 characters for good discoverability
+
+## Optional Fields
+
+### `license`
+
+Short license name or reference to a bundled file (e.g., `Apache-2.0` or `Proprietary. LICENSE.txt has complete terms`).
+
+### `compatibility`
+
+1-500 characters. Include only when the skill has specific environment requirements.
+
+```yaml
+compatibility: Designed for Claude Code (or similar products)
+compatibility: Requires git, docker, jq, and access to the internet
+```
+
+### `metadata`
+
+Arbitrary key-value mapping. Keys and values are strings. Make key names reasonably unique to avoid conflicts.
+
+```yaml
+metadata:
+  author: example-org
+  version: "1.0"
+```
+
+### `allowed-tools`
+
+Space-delimited list of pre-approved tools. Experimental — support varies between agent implementations.
+
+```yaml
+allowed-tools: Bash(git:*) Bash(jq:*) Read
+```
+
+## Progressive Disclosure
+
+Skills should be structured for efficient context use:
+
+| Layer        | Token Budget        | When Loaded                |
+| ------------ | ------------------- | -------------------------- |
+| Metadata     | ~100 tokens         | Startup (all skills)       |
+| Instructions | < 5000 tokens (rec) | When skill is activated    |
+| Resources    | As needed           | When explicitly referenced |
+
+**SKILL.md target**: Under 500 lines. Move detailed reference material to separate files.
+
+## File References
+
+- Use relative paths from the skill root
+- Keep references one level deep from SKILL.md
+- Avoid deeply nested reference chains
+
+```markdown
+See [the reference guide](references/REFERENCE.md) for details.
+Run the extraction script: scripts/extract.py
+```

--- a/references/agents-md-standard.md
+++ b/references/agents-md-standard.md
@@ -1,0 +1,58 @@
+# AGENTS.md Standard
+
+Summary of the [AGENTS.md specification](https://agents.md/) and its relationship to project instruction files like CLAUDE.md.
+
+## What is AGENTS.md?
+
+AGENTS.md is a simple, open format for guiding AI coding agents. It provides a dedicated, predictable place to give agents context and instructions for working on a project. Think of it as "a README for agents."
+
+## Format
+
+- **Standard Markdown** — no required fields, no mandatory schema
+- Use any headings; agents parse the text directly
+- No frontmatter required
+
+## Placement and Scoping
+
+- Place at **repository root** for project-wide instructions
+- **Nested files** in subdirectories take precedence for files within those directories
+- **Closest AGENTS.md** to the edited file wins
+- **Explicit user prompts** override everything
+
+## Common Sections
+
+These are conventions, not requirements:
+
+- Project overview
+- Build and test commands
+- Code style guidelines
+- Testing instructions
+- Security considerations
+- Commit message / PR guidelines
+- Deployment steps
+
+## Relationship to CLAUDE.md
+
+CLAUDE.md is Claude Code's implementation of project instructions. The concepts map directly:
+
+| AGENTS.md Concept        | Claude Code Equivalent   |
+| ------------------------ | ------------------------ |
+| Root AGENTS.md           | Root CLAUDE.md           |
+| Nested AGENTS.md         | Nested CLAUDE.md         |
+| Closest-file-wins        | Same scoping behavior    |
+| User prompts override    | Same override behavior   |
+| Standard Markdown format | Standard Markdown format |
+
+Both serve the same purpose: giving agents project-specific context. Claude Code reads CLAUDE.md files; other agents read AGENTS.md files. A project can have both for cross-agent compatibility.
+
+## Ecosystem Compatibility
+
+AGENTS.md is supported by 20+ coding agents and tools, including Claude Code, VS Code, GitHub Copilot, Cursor, Windsurf, and others. Skills that follow the Agent Skills spec and reference AGENTS.md conventions are portable across this ecosystem.
+
+## Relevance to Skill Validation
+
+When evaluating **portability**, consider:
+
+- Does the skill assume only CLAUDE.md exists, or is it aware of the broader AGENTS.md ecosystem?
+- Could the skill's instructions work conceptually in any AGENTS.md-compatible agent?
+- Are agent-specific tool names or features documented as implementation details rather than hard requirements?

--- a/references/frontmatter-requirements.md
+++ b/references/frontmatter-requirements.md
@@ -107,16 +107,25 @@ description: What and when to use # Required: max 1024 chars
 - **name**: Skill identifier (must match directory name)
 - **description**: What the skill does AND when to use it
 
-### Experimental Fields
+### Optional Fields (spec-standard)
 
-- **allowed-tools**: Restricts tool access (experimental, varying agent support)
+Per the [Agent Skills spec](agent-skills-spec.md#optional-fields):
+
+- **license**: License name or reference to bundled file (e.g., `Apache-2.0`)
+- **compatibility**: Environment requirements, max 500 chars (e.g., `Requires git, docker`)
+- **metadata**: Arbitrary key-value map for additional properties
+- **allowed-tools**: Space-delimited pre-approved tool list (experimental, varying agent support)
 
 ### Naming Rules
 
-- Lowercase letters, numbers, and hyphens only
-- Maximum 64 characters
-- Must match directory name
-- No uppercase, underscores, or special characters
+Per the [Agent Skills spec](agent-skills-spec.md#name-validation-rules):
+
+- 1-64 characters
+- Lowercase alphanumeric and hyphens only (`a-z`, `0-9`, `-`)
+- Must not start or end with a hyphen
+- Must not contain consecutive hyphens (`--`)
+- Must match the parent directory name exactly
+- No uppercase, underscores, spaces, or special characters
 
 ### Description Best Practices
 
@@ -216,7 +225,9 @@ description: When to use this style
 - [ ] `name` matches directory name
 - [ ] `description` includes "what" AND "when"
 - [ ] `description` length is 200-500 chars (recommended)
-- [ ] Only spec-standard frontmatter fields used (`name`, `description`)
+- [ ] Only spec-standard frontmatter fields used (required: `name`, `description`; optional: `license`, `compatibility`, `metadata`, `allowed-tools`)
+- [ ] `name` has no leading/trailing/consecutive hyphens
+- [ ] `description` is under 1024 characters
 
 ## Common Frontmatter Errors
 

--- a/skills/cc-lint/references/common-issues.md
+++ b/skills/cc-lint/references/common-issues.md
@@ -15,7 +15,9 @@ This document catalogs frequent problems found in Claude Code customizations and
 - **Description too short**: <50 chars doesn't provide enough trigger context
 - **Keyword-list description**: Comma-separated keywords instead of prose sentences (e.g., "git, commits, branches, PRs" vs. "Automates git workflows from branch creation through PR submission")
 - **SKILL.md too large**: >500 lines or >5k words without using reference files
-- **Non-standard frontmatter fields**: Using agent-specific extensions without documenting them as implementation-specific
+- **Non-standard frontmatter fields**: Using fields beyond the [spec-standard set](../../references/agent-skills-spec.md#frontmatter-fields) (`name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`) without documenting them as implementation-specific
+- **Invalid name format**: Leading/trailing hyphens, consecutive hyphens (`--`), uppercase, or underscores (see [name validation rules](../../references/agent-skills-spec.md#name-validation-rules))
+- **Description too long**: Exceeds 1024-character spec maximum
 - **Misplaced reference files**: Reference files should live in the references/ subdirectory, not alongside SKILL.md
 - **Orphaned references**: Files not linked from SKILL.md
 

--- a/skills/cc-lint/references/evaluation-criteria.md
+++ b/skills/cc-lint/references/evaluation-criteria.md
@@ -14,12 +14,32 @@ This document defines the correctness, clarity, and effectiveness standards for 
 
 ### Skills
 
-- YAML frontmatter with required fields: name, description
-- Description length >50 chars (should include what AND when)
-- Description is prose, not a comma-separated keyword list
-- Only spec-standard frontmatter fields (no non-standard extensions)
-- Reference files in references/ subdirectory (when needed)
+Per the [Agent Skills spec](../../references/agent-skills-spec.md):
+
+**Name field validation**:
+
+- 1-64 characters, lowercase alphanumeric and hyphens only
+- Must not start or end with a hyphen
+- Must not contain consecutive hyphens (`--`)
+- Must match the parent directory name
+
+**Description field validation**:
+
+- 1-1024 characters (minimum >50 recommended for trigger quality)
+- Must be prose, not a comma-separated keyword list
+- Should include what the skill does AND when to use it
+
+**Frontmatter field validation**:
+
+- Required: `name`, `description`
+- Spec-standard optional: `license`, `compatibility` (max 500 chars), `metadata` (key-value map), `allowed-tools` (space-delimited, experimental)
+- Any other field is non-standard and reduces portability
+
+**Structure validation**:
+
 - SKILL.md as primary file (not arbitrary filename)
+- Reference files in references/ subdirectory (when needed)
+- Assets in assets/, scripts in scripts/
 
 ### Commands
 
@@ -62,9 +82,12 @@ This document defines the correctness, clarity, and effectiveness standards for 
 
 ### Portability (Skills)
 
-- Only spec-standard frontmatter fields used
+Per [Agent Skills spec](../../references/agent-skills-spec.md) and [AGENTS.md standard](../../references/agents-md-standard.md):
+
+- Only spec-standard frontmatter fields used (required: `name`, `description`; optional: `license`, `compatibility`, `metadata`, `allowed-tools`)
 - No agent-specific assumptions baked into structure
-- Content works conceptually across agent implementations
+- Content works conceptually across agent implementations (AGENTS.md ecosystem compatibility)
+- Agent-specific tool names documented as implementation details, not hard requirements
 
 ## Effectiveness Criteria
 

--- a/skills/skill-quality/references/quality-dimensions.md
+++ b/skills/skill-quality/references/quality-dimensions.md
@@ -142,17 +142,20 @@ description: Git workflow automation tool.
 
 **What to evaluate**:
 
-- Does frontmatter use only spec-standard fields (`name`, `description`)?
-- Are agent-specific extensions (e.g., `model`, `context`) absent or clearly documented as implementation-specific?
+Per the [Agent Skills spec](../../references/agent-skills-spec.md) and [AGENTS.md standard](../../references/agents-md-standard.md):
+
+- Does frontmatter use only spec-standard fields?
+- Are agent-specific extensions absent or clearly documented as implementation-specific?
 - Is the markdown structure standard (no proprietary directives)?
-- Could the skill's content work conceptually in another agent?
+- Could the skill's content work conceptually in another AGENTS.md-compatible agent?
 
 **Spec-standard vs. agent-specific**:
 
-| Category       | Examples                                       | Status                     |
-| -------------- | ---------------------------------------------- | -------------------------- |
-| Spec-standard  | `name`, `description`                          | Required by agentskills.io |
-| Agent-specific | `model`, `context`, `disable-model-invocation` | Implementation-dependent   |
+| Category       | Examples                                                | Status                     |
+| -------------- | ------------------------------------------------------- | -------------------------- |
+| Spec required  | `name`, `description`                                   | Required by agentskills.io |
+| Spec optional  | `license`, `compatibility`, `metadata`, `allowed-tools` | Defined by agentskills.io  |
+| Agent-specific | `model`, `context`, `disable-model-invocation`          | Implementation-dependent   |
 
 **Red flags**:
 

--- a/skills/skill-quality/references/scoring-rubric.md
+++ b/skills/skill-quality/references/scoring-rubric.md
@@ -125,10 +125,13 @@ _Does the skill conform to the community spec and work across agents?_
 
 **Evidence to look for**:
 
-- Only `name` and `description` as required frontmatter (per agentskills.io spec)
-- No non-standard or agent-specific frontmatter fields
+Per the [Agent Skills spec](../../references/agent-skills-spec.md) and [AGENTS.md standard](../../references/agents-md-standard.md):
+
+- Required frontmatter: `name`, `description`
+- Spec-standard optional: `license`, `compatibility`, `metadata`, `allowed-tools`
+- Any other frontmatter field is non-standard and reduces portability
 - Standard markdown structure (no proprietary directives)
-- Content works conceptually across agent implementations
+- Content works conceptually across AGENTS.md-compatible agent implementations
 - Agent-specific tool names or features documented as implementation detail, not baked in
 
 ## Calculating the Weighted Score


### PR DESCRIPTION
## Summary

- Add shared `references/agent-skills-spec.md` capturing agentskills.io normative rules (name validation, all frontmatter fields, progressive disclosure token budgets)
- Add shared `references/agents-md-standard.md` covering the AGENTS.md standard and its relationship to CLAUDE.md
- Update cc-lint evaluation criteria with specific name validation rules, description max length, and correct spec-standard field enumeration
- Update skill-quality portability dimension to distinguish spec-required, spec-optional, and agent-specific fields
- Update frontmatter-requirements with missing name rules and all optional spec fields

Fixes incorrect treatment of `license`, `compatibility`, `metadata`, and `allowed-tools` as non-standard fields.

## Test plan

- [ ] Run `/cc-lint` against a skill using optional spec fields — should not flag them as non-standard
- [ ] Run `/skill-quality` on a portable skill — portability scoring should reference correct field categories
- [ ] Verify all cross-reference links resolve (`../../references/agent-skills-spec.md`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)