### PR TITLE
fix: add symlink detection and git add -f guidance to vc-ship

### DIFF
--- a/skills/vc-ship/SKILL.md
+++ b/skills/vc-ship/SKILL.md
@@ -79,6 +79,7 @@ The skill follows an 8-phase workflow:
 | No remote                   | Detect in Phase 1, complete through Phase 5, then end workflow (skip push/PR)                                                      |
 | Protected branch            | BLOCK, require feature branch (see [phase-0-protocol.md](references/phase-0-protocol.md#scenario-1-uncommitted-changes--blocking)) |
 | Rebase in progress          | Alert, offer continue or abort                                                                                                     |
+| Symlinked files             | Detect in Phase 1, exclude from commit plan, inform user                                                                           |
 
 ## User Interaction Patterns
 

--- a/skills/vc-ship/references/workflow-phases.md
+++ b/skills/vc-ship/references/workflow-phases.md
@@ -34,6 +34,7 @@ See **[phase-0-protocol.md](phase-0-protocol.md#detection-order)** for the full 
 - Check for rebase in progress (look for `.git/rebase-merge` or `.git/rebase-apply`)
 - Alert user and stop if conflicts or rebase in progress
 - Check for remotes: `git remote`. If none exist, note this and continue through Phase 5 but skip Phases 6-7 (push/PR) at the end. Inform the user that commits are local-only.
+- Check for symlinks in untracked/changed files: `find <files> -type l`. Symlinked files can't be staged in bare repos or across boundaries. Flag them early and exclude from the Phase 2 commit plan. Inform the user which files were excluded and why.
 
 ## Phase 2: Organize into Atomic Commits
 
@@ -75,6 +76,7 @@ See **[phase-0-protocol.md](phase-0-protocol.md#detection-order)** for the full 
 **For each commit in the plan**:
 
 1. Stage the files: `git add <file1> <file2> ...`
+   - If files are in a gitignored directory but should be tracked, use `git add -f <file>` to force-add them.
 
 2. Generate commit message following these rules:
    - **Summary line**: ≤72 characters, imperative mood, capitalize, no period


### PR DESCRIPTION
## Summary

- Add symlink detection to Phase 1 safety checks so symlinked files are excluded from the commit plan before Phase 3
- Add `git add -f` guidance for staging files in gitignored directories
- Add symlinked files to the edge case quick reference table

## Context

Symlinked skills (installed via `npx skills add -g`) caused `git add` failures at commit time. This fix catches them during repository analysis instead.

## Test plan

- [ ] Run vc-ship in a repo with symlinked files — verify they're flagged in Phase 1 and excluded from commit plan
- [ ] Run vc-ship with files in a gitignored directory — verify `git add -f` is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)