### PR TITLE
docs: add bare repo edge case to vc-ship

### DIFF
--- a/skills/vc-ship/SKILL.md
+++ b/skills/vc-ship/SKILL.md
@@ -80,6 +80,7 @@ The skill follows an 8-phase workflow:
 | Protected branch            | BLOCK, require feature branch (see [phase-0-protocol.md](references/phase-0-protocol.md#scenario-1-uncommitted-changes--blocking)) |
 | Rebase in progress          | Alert, offer continue or abort                                                                                                     |
 | Symlinked files             | Detect in Phase 1, exclude from commit plan, inform user                                                                           |
+| Bare git repo               | Not supported — use the repo's wrapper command (e.g., `dot`) for bare repo operations                                              |
 
 ## User Interaction Patterns
 


### PR DESCRIPTION
## Summary

- Add bare git repo to vc-ship edge case table, noting it's not supported and directing users to their repo's wrapper command

## Context

vc-ship has no awareness of bare repo patterns (`--git-dir`/`--work-tree`). Rather than adding support, document the limitation clearly.

## Test plan

- [ ] Verify edge case table renders correctly in SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)