### PR TITLE
docs: add branch rename note to vc-ship Phase 0

### DIFF
--- a/skills/vc-ship/references/phase-0-protocol.md
+++ b/skills/vc-ship/references/phase-0-protocol.md
@@ -30,6 +30,8 @@ Present 3 options via AskUserQuestion:
 4. **Execute migration**: `git stash push -u` → `git checkout -b {name}` → `git stash pop`
 5. **On failure**: rollback — return to protected branch, delete new branch, restore stash
 
+> **Note**: The auto-suggested branch name is based on changed files at detection time. If Phase 1 excludes files (symlinks, secrets), consider renaming the branch before push: `git branch -m <old> <new>`.
+
 ### Option 2: Custom branch name
 
 Ask user for name. Validate it starts with a standard prefix (feature/, fix/, etc.). If not, offer to prepend `feature/`. Execute same stash/checkout/pop migration.


### PR DESCRIPTION
## Summary

- Add note to Phase 0 Option 1 (auto-suggest) reminding that branch names may become stale if Phase 1 excludes files, with `git branch -m` guidance

## Context

Branch names are generated from changed files at Phase 0, before Phase 1 filters out uncommittable files (symlinks, secrets). This can leave a misleading branch name.

## Test plan

- [ ] Verify note renders correctly in phase-0-protocol.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)