### PR TITLE
docs: mention PR template sections in vc-ship overview

### DIFF
--- a/skills/vc-ship/SKILL.md
+++ b/skills/vc-ship/SKILL.md
@@ -51,7 +51,7 @@ The skill follows an 8-phase workflow:
 4. **Commit History Cleanup** - Optionally reorganize commits before push
 5. **Pre-Push Quality Review** - Analyze commit quality and run tests (MANDATORY)
 6. **Push with Confirmation** - Push changes to remote after approval
-7. **Pull Request Creation** - Optionally create PR with generated description
+7. **Pull Request Creation** - Optionally create PR with generated description (Summary, Changes, Breaking Changes, Dependencies, Testing, Related Issues sections)
 
 | Phase | Goal                | Key Actions                                              | Reference                                                                                  |
 | ----- | ------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
## Summary

- Add PR description section names to Phase 7 overview line in SKILL.md

## Context

The rich PR template in workflow-phases.md wasn't referenced in the SKILL.md overview, making it less discoverable.

## Test plan

- [ ] Verify Phase 7 line reads clearly with the added section names

🤖 Generated with [Claude Code](https://claude.com/claude-code)