### PR TITLE
chore: remove model setting from settings.json

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -39,7 +39,6 @@
     "deny": ["Edit(.env*)", "Read(.env*)", "Write(.env*)", "Bash(sudo:*)"],
     "defaultMode": "acceptEdits"
   },
-  "model": "opus",
   "hooks": {
     "InstructionsLoaded": [
       {


### PR DESCRIPTION
## Summary

- Remove pinned `"model": "opus"` from settings.json to use default model selection via `/model` command instead

## Testing

- [x] Verify Claude Code starts without errors and uses the expected default model

🤖 Generated with [Claude Code](https://claude.com/claude-code)