### PR TITLE
chore: gitignore newly installed symlinked skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,14 @@ logs/
 skills/.marketplace/
 
 # Symlinked skills (installed via `npx skills add -g`)
+skills/brainstorming
 skills/defuddle
+skills/executing-plans
 skills/find-skills
+skills/requesting-code-review
+skills/systematic-debugging
+skills/test-driven-development
+skills/writing-plans
 
 # My local Claude config for the Claude config
 .claude/


### PR DESCRIPTION
## Summary
- Add 6 newly installed symlinked skills to .gitignore (brainstorming, executing-plans, requesting-code-review, systematic-debugging, test-driven-development, writing-plans)

## Test plan
- [x] Verify symlinked skills no longer appear in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)