### PR TITLE
fix: bound stdin read in validate-config.py to 1MB

### DIFF
--- a/hooks/validate-config.py
+++ b/hooks/validate-config.py
@@ -79,7 +79,8 @@ def validate_skill(frontmatter, file_path):
 
 
 try:
-    data = json.load(sys.stdin)
+    raw = sys.stdin.read(1_048_576)  # 1MB limit
+    data = json.loads(raw)
 
     # Early file path filtering - extract path first, before content
     file_path = data.get("tool_input", {}).get("file_path", "")


### PR DESCRIPTION
## Summary

- Adds a 1MB size guard to `hooks/validate-config.py` stdin read, preventing unbounded memory consumption from oversized payloads

## Changes

- Replace `json.load(sys.stdin)` with bounded `sys.stdin.read(1_048_576)` + `json.loads()`

## Testing

- [x] `ruff check` and `ruff format --check` pass
- [x] Manual review of diff confirms minimal, focused change

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)