### PR TITLE
fix: log formatter failures in auto-format.sh

### DIFF
--- a/hooks/auto-format.sh
+++ b/hooks/auto-format.sh
@@ -26,17 +26,29 @@ fi
 # Format based on file extension
 case "$file_path" in
 *.go)
-	command -v gofmt &>/dev/null && gofmt -w "$file_path"
+	if command -v gofmt &>/dev/null; then
+		if ! gofmt -w "$file_path" 2>/dev/null; then
+			echo "[auto-format] gofmt failed on $file_path" >&2
+		fi
+	fi
 	;;
 *.ts | *.tsx | *.js | *.jsx | *.json | *.yaml | *.yml)
-	command -v prettier &>/dev/null && prettier --write "$file_path"
+	if command -v prettier &>/dev/null; then
+		if ! prettier --write "$file_path" 2>/dev/null; then
+			echo "[auto-format] prettier failed on $file_path" >&2
+		fi
+	fi
 	;;
 *.md)
 	basename=$(basename "$file_path")
 	if [ "$basename" = "walkthrough.md" ]; then
 		exit 0 # Managed by showboat — prettier would break verified output blocks
 	fi
-	command -v prettier &>/dev/null && prettier --write "$file_path"
+	if command -v prettier &>/dev/null; then
+		if ! prettier --write "$file_path" 2>/dev/null; then
+			echo "[auto-format] prettier failed on $file_path" >&2
+		fi
+	fi
 	;;
 esac
 


### PR DESCRIPTION
## Summary

- Captures formatter exit codes and logs failures to stderr instead of silently swallowing them
- Hook still exits 0 in all cases (never blocks the session)

## Changes

- Wrap `gofmt` and `prettier` calls in `if !` blocks with `[auto-format]` prefixed error messages
- Consistent pattern across all three formatter invocations (Go, JS/TS/JSON/YAML, Markdown)

## Testing

- [x] `shellcheck` passes
- [x] `shfmt -d` passes (no formatting drift)
- [x] Manual review confirms exit 0 preserved in all paths

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)