### PR TITLE
feat: add CI linting workflow for PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+
+      - name: Run checks
+        run: task check


### PR DESCRIPTION
## Summary

- Adds a new `lint.yml` GitHub Actions workflow that runs `task check` on pushes to main and PRs
- Catches formatting and linting regressions (prettier, biome, shellcheck, ruff) before merge

## Changes

- New `.github/workflows/lint.yml` with Bun, uv, and Task setup steps

## Testing

- [x] Prettier formatting verified
- [x] Workflow syntax reviewed against GitHub Actions schema
- [x] All `task check` subtasks use read-only lint commands (CI-safe)

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)