### PR TITLE
refactor: simplify hooks and improve consistency

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/hooks/auto-format.sh
+++ b/hooks/auto-format.sh
@@ -23,32 +23,31 @@ if [ -z "$file_path" ]; then
 	exit 0
 fi
 
+# Run a formatter if available, log failures
+try_format() {
+	local tool="$1" file="$2"
+	shift 2
+	if command -v "$tool" &>/dev/null; then
+		if ! "$tool" "$@" "$file" 2>/dev/null; then
+			echo "[auto-format] $tool failed on $file" >&2
+		fi
+	fi
+}
+
 # Format based on file extension
 case "$file_path" in
 *.go)
-	if command -v gofmt &>/dev/null; then
-		if ! gofmt -w "$file_path" 2>/dev/null; then
-			echo "[auto-format] gofmt failed on $file_path" >&2
-		fi
-	fi
+	try_format gofmt "$file_path" -w
 	;;
 *.ts | *.tsx | *.js | *.jsx | *.json | *.yaml | *.yml)
-	if command -v prettier &>/dev/null; then
-		if ! prettier --write "$file_path" 2>/dev/null; then
-			echo "[auto-format] prettier failed on $file_path" >&2
-		fi
-	fi
+	try_format prettier "$file_path" --write
 	;;
 *.md)
 	basename=$(basename "$file_path")
 	if [ "$basename" = "walkthrough.md" ]; then
 		exit 0 # Managed by showboat — prettier would break verified output blocks
 	fi
-	if command -v prettier &>/dev/null; then
-		if ! prettier --write "$file_path" 2>/dev/null; then
-			echo "[auto-format] prettier failed on $file_path" >&2
-		fi
-	fi
+	try_format prettier "$file_path" --write
 	;;
 esac
 

--- a/hooks/load-session-context.sh
+++ b/hooks/load-session-context.sh
@@ -9,7 +9,7 @@ if [ ! -d .git ]; then
 	exit 0
 fi
 
-if command -v gh &>/dev/null && gh repo view &>/dev/null 2>&1; then
+if command -v gh &>/dev/null && git remote get-url origin 2>/dev/null | grep -q github.com; then
 	echo "### Open GitHub Issues"
 	gh issue list --state open --limit 5 2>/dev/null || echo "No open issues"
 	echo ""

--- a/hooks/statusline-command.sh
+++ b/hooks/statusline-command.sh
@@ -4,9 +4,11 @@
 
 input=$(cat)
 
-cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd')
-model=$(echo "$input" | jq -r '.model.display_name // empty')
-remaining=$(echo "$input" | jq -r '.context_window.remaining_percentage // empty')
+read -r cwd model remaining < <(echo "$input" | jq -r '[
+  (.workspace.current_dir // .cwd),
+  (.model.display_name // ""),
+  (.context_window.remaining_percentage // "")
+] | @tsv')
 
 # --- Directory (truncated to 3 segments, repo-relative when in a git repo) ---
 git_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)

--- a/hooks/validate-bash-commands.py
+++ b/hooks/validate-bash-commands.py
@@ -18,7 +18,8 @@ ANTI_PATTERNS = [
 ]
 
 try:
-    data = json.load(sys.stdin)
+    raw = sys.stdin.read(1_048_576)  # 1MB limit, consistent with validate-config.py
+    data = json.loads(raw)
     command = data.get("tool_input", {}).get("command", "")
 
     if not command:

--- a/hooks/validate-config.py
+++ b/hooks/validate-config.py
@@ -18,9 +18,8 @@ except ImportError:
     print("Warning: pyyaml not installed — config validation skipped", file=sys.stderr)
     sys.exit(0)
 
-# Extension-specific validation rules
-AGENT_REQUIRED_FIELDS = ["name", "description"]
-SKILL_REQUIRED_FIELDS = ["name", "description"]
+# Required frontmatter fields (shared by agents and skills)
+REQUIRED_FIELDS = ["name", "description"]
 
 
 def extract_frontmatter(content):
@@ -39,7 +38,7 @@ def validate_agent(frontmatter, file_path):
     errors = []
 
     # Check required fields
-    for field in AGENT_REQUIRED_FIELDS:
+    for field in REQUIRED_FIELDS:
         if field not in frontmatter:
             errors.append(f"Missing required field: {field}")
 
@@ -59,7 +58,7 @@ def validate_skill(frontmatter, file_path):
     errors = []
 
     # Check required fields
-    for field in SKILL_REQUIRED_FIELDS:
+    for field in REQUIRED_FIELDS:
         if field not in frontmatter:
             errors.append(f"Missing required field: {field}")
 


### PR DESCRIPTION
## Summary

- Extract `try_format` helper in `auto-format.sh` to eliminate triplicated command-check-and-run pattern
- Consolidate duplicate `REQUIRED_FIELDS` constants in `validate-config.py`
- Add bounded stdin read to `validate-bash-commands.py` (consistency with sibling hook)
- Merge three `jq` calls into one in `statusline-command.sh` (fewer process spawns)
- Replace `gh repo view` network call with local `git remote` check in `load-session-context.sh`
- Enable uv cache in CI workflow

## Test plan

- [x] All bash hooks pass `bash -n` syntax check
- [x] All python hooks pass `py_compile` syntax check
- [ ] Verify status line renders correctly in a new session
- [ ] Verify auto-format hook formats a `.md` file on Edit
- [ ] Verify session start loads GitHub issues without delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)