### PR TITLE
refactor: simplify statusline display

### DIFF
--- a/hooks/statusline-command.sh
+++ b/hooks/statusline-command.sh
@@ -4,11 +4,9 @@
 
 input=$(cat)
 
-read -r cwd model remaining < <(echo "$input" | jq -r '[
-  (.workspace.current_dir // .cwd),
-  (.model.display_name // ""),
-  (.context_window.remaining_percentage // "")
-] | @tsv')
+cwd=$(echo "$input" | jq -r '(.workspace.current_dir // .cwd)')
+model=$(echo "$input" | jq -r '(.model.display_name // "")')
+remaining=$(echo "$input" | jq -r '(.context_window.remaining_percentage // "")')
 
 # --- Directory (truncated to 3 segments, repo-relative when in a git repo) ---
 git_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)
@@ -48,10 +46,12 @@ fi
 parts=()
 parts+=("$dir_display")
 [ -n "$branch" ] && parts+=("$branch${git_sym:+ $git_sym}")
-[ -n "$model" ] && parts+=("$model")
-[ -n "$remaining" ] && parts+=("ctx ${remaining}%")
+[ -n "$model" ] && parts+=("${model%% *}")
+[ -n "$remaining" ] && parts+=("${remaining}%")
 
-printf '%s' "$(
-	IFS=' | '
-	echo "${parts[*]}"
-)"
+result=""
+for i in "${!parts[@]}"; do
+	[ "$i" -gt 0 ] && result+=" · "
+	result+="${parts[$i]}"
+done
+printf '%s' "$result"


### PR DESCRIPTION
## Summary

- Drop model version number and "ctx" label for cleaner status line output
- Switch from pipe (`|`) to middle dot (`·`) separators
- Fix multi-byte IFS bug by joining parts with explicit loop
- Extract jq fields individually to handle spaces in model display names

## Test plan

- [ ] Verify status line renders as `dir · branch · Opus · 89%`
- [ ] Confirm no separator artifacts or missing delimiters

🤖 Generated with [Claude Code](https://claude.com/claude-code)