### PR TITLE
chore: replace symlinked skills with official plugins

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -120,13 +120,27 @@
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
-    "gopls-lsp@claude-plugins-official": true
+    "gopls-lsp@claude-plugins-official": true,
+    "superpowers@superpowers-dev": true,
+    "obsidian@obsidian-skills": true
   },
   "extraKnownMarketplaces": {
     "claude-plugins-official": {
       "source": {
         "source": "github",
         "repo": "anthropics/claude-plugins-official"
+      }
+    },
+    "superpowers-dev": {
+      "source": {
+        "source": "github",
+        "repo": "obra/superpowers"
+      }
+    },
+    "obsidian-skills": {
+      "source": {
+        "source": "github",
+        "repo": "kepano/obsidian-skills"
       }
     }
   },


### PR DESCRIPTION
## Summary

- Replace npx-skills symlinks (brainstorming, defuddle, executing-plans, writing-plans, find-skills) with Claude Code's native plugin system
- Add obra/superpowers and kepano/obsidian-skills as plugin marketplaces
- Skills now load as namespaced plugins (`superpowers:*`, `obsidian:*`)

## Changes

- `settings.json`: Add `superpowers@superpowers-dev` and `obsidian@obsidian-skills` to `enabledPlugins`
- `settings.json`: Add marketplace sources for `obra/superpowers` and `kepano/obsidian-skills`
- Removed 5 symlinks from `skills/` directory (brainstorming, defuddle, executing-plans, writing-plans, find-skills)

## Test plan

- [ ] Restart Claude Code session
- [ ] Verify `/superpowers:brainstorming` and `/obsidian:defuddle` skills load
- [ ] Confirm no stale symlinks remain in `skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)