### PR TITLE
chore: replace symlinks with plugins, remove stale MCP entry

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -45,7 +45,6 @@
       "WebFetch(domain:ampcode.com)",
       "Bash(skill-validator:*)",
       "Bash(skill-validator check:*)",
-      "mcp__obsidian__create_note",
       "mcp__github__issue_write",
       "Bash(claude plugin:*)"
     ],


### PR DESCRIPTION
## Summary

- Replace symlinked skills (defuddle, obsidian-cli, etc.) with official plugin installs from kepano/obsidian-skills and obra/superpowers marketplaces
- Remove stale `mcp__obsidian__create_note` allow entry — MCP tools come from the desktop app config, not Claude Code settings

## Test plan

- [ ] Verify `/obsidian-cli` skill loads from plugin
- [ ] Verify `/defuddle` skill loads from plugin
- [ ] Confirm no `mcp__obsidian__` permission prompts in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)