### PR TITLE
fix(session-review): use obsidian CLI instead of MCP tool

### DIFF
--- a/skills/session-review/SKILL.md
+++ b/skills/session-review/SKILL.md
@@ -137,10 +137,12 @@ Based on the analysis, generate applicable items:
 
 ## Obsidian Storage
 
-After presenting the review, always save it to Obsidian using
-`mcp__obsidian__create_note`:
+After presenting the review, save it to Obsidian using the `obsidian` CLI (invoke the `obsidian-cli` skill for reference):
 
-- **Filename:** `Session Reviews/YYYY-MM-DD <short description>.md`
+```bash
+obsidian create path="Session Reviews/YYYY-MM-DD <short description>.md" content="<review content>" silent
+```
+
 - **Title:** `# Session Review: <short description>`
 - **Date** and **repo/project** as metadata at the top
 - Use the same markdown content shown to the user


### PR DESCRIPTION
## Summary

- Replace `mcp__obsidian__create_note` with `obsidian create` CLI command for saving session reviews
- Aligns with the `obsidian-cli` skill plugin and removes MCP server dependency

## Test plan

- [x] Run `/session-review` and verify it uses `obsidian create` to save the note
- [x] Confirm the note appears in the `Session Reviews/` folder in the vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)