### PR TITLE
refactor: standardize skill descriptions to three-part pattern

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -29,7 +29,7 @@ Skills follow the [Agent Skills specification](https://agentskills.io/specificat
 - Required frontmatter: `name`, `description` (with trigger phrases)
 - Name must be kebab-case, match the directory name, max 64 chars
 - Description must use **third-person voice** ("Analyzes...", not "Analyze...")
-- Description should include **what** it does and **when** to use it (200-500 chars)
+- Description follows three-part pattern: **[What it does]. Use when [triggers]. [Key capabilities].** (200-500 chars)
 - Reference files exceeding 100 lines should include a `## Contents` TOC
 - Naming uses prefix conventions per `naming-conventions.md`: `cc-` for Claude Code meta-tools, `vc-` for version control, `md-` for CLAUDE.md operations, no prefix for general-purpose skills
 
@@ -96,6 +96,17 @@ bunx biome check --fix
 - One atomic commit per logical change
 - Use `/vc-ship` for the full 8-phase ship process (branch, analyze, organize, commit, cleanup, review, push, PR)
 - `.claude/` is gitignored but contains tracked files — always use `git add -f` for new files in this directory
+
+## Skill Rename Protocol
+
+When renaming a skill:
+
+1. `mv skills/<old> skills/<new>` — rename directory
+2. Update `name:` in SKILL.md frontmatter to match new directory
+3. `grep -r "<old-name>" --include="*.md" --include="*.json"` — find all stale references
+4. Update every reference (README, skill-groups, settings.json, walkthrough, cross-skill refs)
+5. Check `settings.local.json` for stale `Skill()` entries (not tracked in git, easy to miss)
+6. `grep -r "<old-name>"` — verify zero results remain
 
 ## Evaluation-Driven Workflow
 

--- a/skills/bash-quality-gate/SKILL.md
+++ b/skills/bash-quality-gate/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: bash-quality-gate
-description: >-
-  Runs shell script quality checks — formatting, static analysis, and
-  portability. Use when checking shell script quality, linting bash code, or
-  validating scripts with shellcheck and shfmt.
+description: Runs shell script quality checks. Use when checking shell script quality, linting bash code, or validating scripts. Covers formatting with shfmt, static analysis with shellcheck, and portability checks.
 ---
 
 # Bash Quality Gate

--- a/skills/cc-automation-recommender/SKILL.md
+++ b/skills/cc-automation-recommender/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-automation-recommender
-description: Analyzes a codebase and recommends Claude Code automations (hooks, subagents, skills, plugins, MCP servers). Use when user asks for automation recommendations, wants to optimize their Claude Code setup, mentions improving Claude Code workflows, asks how to first set up Claude Code for a project, wants to know what Claude Code features they should use, asks about Claude Code best practices, or wants to know what tools to install for Claude Code.
+description: Analyzes a codebase and recommends Claude Code automations. Use when asking for automation recommendations, optimizing Claude Code setup, or setting up Claude Code for a project. Covers hooks, subagents, skills, plugins, and MCP servers.
 ---
 
 **This skill is read-only.** It analyzes the codebase and outputs recommendations. It does NOT create or modify any files. Users implement the recommendations themselves or ask Claude separately to help build them.

--- a/skills/cc-check/SKILL.md
+++ b/skills/cc-check/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: cc-check
-description: >-
-  Runs systematic tests on Claude Code customizations — skills, agents, hooks,
-  and commands. Executes sample queries and validates responses against expected
-  behavior. Use when testing whether a customization works correctly or when
-  running functional and regression tests.
+description: Runs systematic tests on Claude Code customizations. Use when testing whether a customization works correctly or running functional and regression tests. Executes sample queries and validates responses against expected behavior for skills, agents, hooks, and commands.
 ---
 
 ## Reference Files

--- a/skills/cc-lint/SKILL.md
+++ b/skills/cc-lint/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: cc-lint
-description: >-
-  Performs quick structural validation of Claude Code customizations against
-  the Agent Skills spec. Checks YAML frontmatter and required fields along
-  with naming conventions and file organization. Also validates settings.json
-  health. Use when linting or reviewing any customization for correctness.
+description: Performs quick structural validation of Claude Code customizations. Use when linting or reviewing any customization for correctness. Checks YAML frontmatter, required fields, naming conventions, file organization, and settings.json health against the Agent Skills spec.
 ---
 
 ## Reference Files

--- a/skills/cc-lint/references/evaluation-criteria.md
+++ b/skills/cc-lint/references/evaluation-criteria.md
@@ -33,7 +33,7 @@ Per the [Agent Skills spec](../../../references/agent-skills-spec.md):
 
 - 1-1024 characters (minimum >50 recommended for trigger quality)
 - Must be prose, not a comma-separated keyword list
-- Should include what the skill does AND when to use it
+- Must follow three-part pattern: **[What it does]. Use when [triggers]. [Key capabilities].**
 
 **Frontmatter field validation**:
 
@@ -108,9 +108,8 @@ Per [Agent Skills spec](../../../references/agent-skills-spec.md) and [AGENTS.md
 
 ### Triggering Quality (Skills)
 
-- Description contains trigger phrases
+- Description follows three-part pattern: [What]. Use when [triggers]. [Capabilities].
 - "When to use" info in frontmatter description (NOT body)
-- Use cases clearly mentioned
 - Keywords align with user queries
 
 ### Integration Quality

--- a/skills/fix-issue/SKILL.md
+++ b/skills/fix-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fix-issue
-description: Plans, implements, reviews, and ships a fix for a GitHub issue. Handles fork workflows with upstream detection. Use when fixing a GitHub issue, resolving a bug report, implementing a feature request from an issue, working on issue numbers, closing an issue, or addressing a ticket.
+description: Plans, implements, reviews, and ships a fix for a GitHub issue. Use when fixing an issue, resolving a bug report, implementing a feature request, or closing a ticket. Handles fork workflows, upstream detection, branch creation, and PR submission.
 ---
 
 ## Reference Files

--- a/skills/go-quality-gate/SKILL.md
+++ b/skills/go-quality-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-quality-gate
-description: Runs Go code quality checks — formatting, static analysis, and tests. Use when checking Go code quality, linting Go code, running Go checks, validating Go code, go quality gate, check my Go project, or run go lint.
+description: Runs Go code quality checks. Use when checking Go code quality, linting, running checks, or validating a Go project. Covers formatting with gofmt, static analysis with go vet, and test execution.
 ---
 
 # Go Quality Gate

--- a/skills/last30days/SKILL.md
+++ b/skills/last30days/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: last30days
-description: "Research any topic from the last 30 days across Reddit, X, YouTube, Hacker News, and the web. Surfaces what people are discussing, recommending, and debating right now. Use when researching current topics, finding what's trending, getting recent discussions, best/top recommendations, prompting techniques, looking up what people are saying about something, searching for recent news, finding out what's new with a topic, or getting community opinions on something."
+description: "Researches any topic from the last 30 days. Use when researching current topics, finding what's trending, getting recent discussions, or looking up community opinions. Searches Reddit, X, YouTube, Hacker News, and the broader web for what people are discussing and recommending."
 ---
 
 # last30days: Research Any Topic from the Last 30 Days

--- a/skills/let-fate-decide/SKILL.md
+++ b/skills/let-fate-decide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: let-fate-decide
-description: "Draws 4 Tarot cards using os.urandom() to inject entropy into planning when prompts are vague or underspecified. Interprets the spread to guide next steps. Use when the user is nonchalant, feeling lucky, says 'let fate decide', makes Yu-Gi-Oh references ('heart of the cards'), demonstrates indifference about approach, or says 'try again' on a system with no changes. Also triggers on sufficiently ambiguous prompts where multiple approaches are equally valid."
+description: "Draws 4 Tarot cards using os.urandom() to inject entropy into planning. Use when prompts are vague, the user says 'let fate decide', makes Yu-Gi-Oh references, demonstrates indifference about approach, or multiple approaches are equally valid. Interprets the spread to generate actionable next steps from randomized input."
 allowed-tools:
   - Bash
   - Read

--- a/skills/md-audit/SKILL.md
+++ b/skills/md-audit/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: md-audit
-description: >-
-  Audits and improves CLAUDE.md files by scanning repositories and evaluating
-  quality against templates. Outputs a quality report with scores and applies
-  targeted updates. Use for CLAUDE.md maintenance and optimization or when
-  reviewing what project instructions should contain.
+description: Audits and improves CLAUDE.md files by scanning repositories. Use for CLAUDE.md maintenance and optimization or when reviewing what project instructions should contain. Evaluates quality against templates, outputs scored reports, and applies targeted updates.
 ---
 
 **This skill can write to CLAUDE.md files.** After presenting a quality report and getting user approval, it updates CLAUDE.md files with targeted improvements.

--- a/skills/md-improve/SKILL.md
+++ b/skills/md-improve/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: md-improve
-description: >-
-  Improves CLAUDE.md by analyzing conversation patterns to capture recurring
-  preferences and corrections. Use when Claude keeps repeating a mistake, when
-  you want to teach it a new preference, when consolidating guidance from
-  repeated instructions, when Claude ignores your style preferences, or when
-  you want to update project instructions based on what you learned this session.
+description: Improves CLAUDE.md by analyzing conversation patterns. Use when Claude keeps repeating a mistake, when teaching a new preference, or when consolidating guidance from repeated instructions. Captures recurring corrections and style preferences into project instructions.
 ---
 
 # Improve Instructions

--- a/skills/pre-release/SKILL.md
+++ b/skills/pre-release/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: pre-release
-description: >-
-  Pre-release gate that validates a project is ready to tag and ship.
-  Runs through a checklist of repo hygiene, CI, docs, version sync,
-  and build verification. Use before tagging a release, cutting a
-  version, shipping a package, or when asking "are we ready to release?"
+description: Validates a project is ready to tag and ship. Use before tagging a release, cutting a version, shipping a package, or when asking "are we ready to release?" Checks repo hygiene, CI status, docs, version sync, and build verification.
 ---
 
 # Pre-Release Gate

--- a/skills/python-quality-gate/SKILL.md
+++ b/skills/python-quality-gate/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: python-quality-gate
-description: >-
-  Runs Python code quality checks — formatting, linting, type checking, and
-  tests. Use when checking Python code quality, linting with ruff, type
-  checking with mypy, or running pytest.
+description: Runs Python code quality checks. Use when checking Python quality, linting, type checking, or running tests. Covers formatting and linting with ruff, type checking with mypy, and test execution with pytest.
 ---
 
 # Python Quality Gate

--- a/skills/refactor-clean/SKILL.md
+++ b/skills/refactor-clean/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: refactor-clean
-description: >-
-  Refactors and cleans up code by detecting smells and applying structured
-  improvements. Use when code is too complex, hard to maintain, or has
-  duplication. Handles simplification, decomposition, SOLID violations, and
-  extract-method refactoring.
+description: Refactors and cleans up code by detecting smells and applying structured improvements. Use when code is too complex, hard to maintain, or has duplication. Handles simplification, decomposition, SOLID violations, and extract-method refactoring.
 ---
 
 # Refactor and Clean Code

--- a/skills/session-review/SKILL.md
+++ b/skills/session-review/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: session-review
-description: >-
-  Analyzes the current session to extract patterns, preferences, and learnings.
-  Produces a structured review capturing what worked and what to improve. Use
-  for session retrospectives, debriefs, post-mortems, or when reflecting on
-  insights worth remembering.
+description: Analyzes the current session to extract patterns, preferences, and learnings. Use for session retrospectives, debriefs, post-mortems, or reflecting on insights worth remembering. Produces structured reviews capturing what worked, what to improve, and actionable takeaways.
 ---
 
 # Session Review

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Creates new Claude Code skills from scratch or from conversation context. Use when users want to make a skill, create a skill, turn this into a skill, build a new customization, capture a workflow as a reusable skill, write a skill, design a skill, generate a skill, or draft a new skill.
+description: Creates new Claude Code skills from scratch or from conversation context. Use when wanting to make, design, or draft a skill, or capture a workflow as a reusable customization. Generates SKILL.md with frontmatter, references, and directory structure.
 ---
 
 # Skill Creator
@@ -34,7 +34,7 @@ Based on the user interview, write a complete SKILL.md with these components:
 #### Frontmatter (required)
 
 - **name**: Skill identifier — kebab-case, lowercase letters/digits/hyphens only, no leading/trailing/consecutive hyphens, max 64 characters. The directory name must match this value.
-- **description**: When to trigger and what it does. Must use **third-person voice** ("Analyzes...", "Generates...", not "Analyze...", "Generate..."). This is the primary triggering mechanism — include both what the skill does AND specific phrases/contexts for when to use it. Max 1024 characters, no angle brackets.
+- **description**: Three-part pattern: **[What it does]. Use when [triggers]. [Key capabilities].** Must use **third-person voice** ("Analyzes...", "Generates...", not "Analyze...", "Generate..."). This is the primary triggering mechanism. Max 1024 characters, no angle brackets.
 - Optional fields: `license` (SPDX identifier), `compatibility` (runtime requirements), `allowed-tools` (restrict tool access), `metadata` (arbitrary key-value pairs)
 
 #### Body

--- a/skills/skill-improve/SKILL.md
+++ b/skills/skill-improve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-improve
-description: Generates prioritized improvement recommendations for Claude Code skills. Use when improving skills, getting skill suggestions, enhancing customizations, or wanting actionable feedback on how to make a skill better. Provides impact/effort prioritization.
+description: Generates prioritized improvement recommendations for Claude Code skills. Use when improving skills, enhancing customizations, or wanting actionable feedback on how to make a skill better. Provides impact/effort prioritization with specific fix suggestions.
 ---
 
 ## Reference Files

--- a/skills/skill-improve/references/improvement-categories.md
+++ b/skills/skill-improve/references/improvement-categories.md
@@ -221,13 +221,14 @@ Not all skills need the same verification depth:
 
 **Common improvements**:
 
-| Issue             | Recommendation                                                                          |
-| ----------------- | --------------------------------------------------------------------------------------- |
-| Short description | Expand with trigger phrases and use cases (target 200-500 chars)                        |
-| Missing synonyms  | Add variations: "commit" → "commit, committing, make commits"                           |
-| No "use when"     | Add "Use when..." clause to description                                                 |
-| Technical only    | Add natural language: "git workflow" → "git workflow, shipping code, preparing changes" |
-| Single phrasing   | Add 3-5 alternative ways users might ask                                                |
+| Issue               | Recommendation                                                                          |
+| ------------------- | --------------------------------------------------------------------------------------- |
+| Missing three parts | Restructure as: [What it does]. Use when [triggers]. [Key capabilities].                |
+| Short description   | Expand with trigger phrases and capabilities (target 200-500 chars)                     |
+| Missing synonyms    | Add variations: "commit" → "commit, committing, make commits"                           |
+| No "use when"       | Add "Use when..." clause as second sentence                                             |
+| No capabilities     | Add third sentence listing key features, tools, or outputs                              |
+| Technical only      | Add natural language: "git workflow" → "git workflow, shipping code, preparing changes" |
 
 **Impact indicators**:
 

--- a/skills/skill-quality/SKILL.md
+++ b/skills/skill-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-quality
-description: Rates Claude Code skills with numerical scores (1-5) across 6 quality dimensions including verification. Use when evaluating skill quality, scoring skills, rating customizations, or comparing skill effectiveness. Provides weighted scores and quality tier assessment.
+description: Rates Claude Code skills with numerical scores (1-5) across 6 quality dimensions. Use when evaluating skill quality, scoring skills, or comparing skill effectiveness. Produces weighted scores, quality tier assessment, and verification results.
 ---
 
 ## Reference Files

--- a/skills/skill-quality/references/quality-dimensions.md
+++ b/skills/skill-quality/references/quality-dimensions.md
@@ -142,20 +142,21 @@ Not all skills need the same level of verification. Score according to the skill
 
 **What to evaluate**:
 
-- Does description contain natural trigger phrases?
-- Are synonyms and variations covered?
+- Does description follow the three-part pattern: [What]. Use when [triggers]. [Capabilities].?
+- Are synonyms and variations covered in the trigger section?
 - Does it match how users actually phrase requests?
-- Is "when to use" guidance clear?
+- Is the capabilities section distinct from the "what" section?
 
 **Good trigger patterns**:
 
 ```yaml
-# Good: Multiple natural phrases
-description: Automates git workflows with branch management, atomic commits,
-  history cleanup, and PRs. Use when committing, pushing, creating PRs,
-  cleaning up commits, or organizing git changes.
+# Good: Three-part pattern
+description: Automates end-to-end git workflows from branch creation through PR
+  submission. Use when shipping code, preparing changes for review, committing
+  and pushing, or creating pull requests. Organizes atomic commits, cleans
+  history, runs quality checks, and manages branch lifecycle.
 
-# Poor: Single technical phrase
+# Poor: Missing capabilities, no structure
 description: Git workflow automation tool.
 ```
 

--- a/skills/skill-quality/references/scoring-rubric.md
+++ b/skills/skill-quality/references/scoring-rubric.md
@@ -123,20 +123,20 @@ _Does it follow Claude Code skill best practices?_
 
 _Will users discover and successfully invoke this skill?_
 
-| Score | Criteria                                                                                                             |
-| ----- | -------------------------------------------------------------------------------------------------------------------- |
-| **5** | Description contains multiple natural trigger phrases. Covers synonyms and variations. Clear "when to use" guidance. |
-| **4** | Good trigger phrases in description. Most common invocations covered.                                                |
-| **3** | Some trigger phrases. May miss common ways users ask for this functionality.                                         |
-| **2** | Few trigger phrases. Users likely won't discover it naturally.                                                       |
-| **1** | No meaningful trigger phrases. Skill unlikely to be invoked.                                                         |
+| Score | Criteria                                                                                                              |
+| ----- | --------------------------------------------------------------------------------------------------------------------- |
+| **5** | Three-part pattern ([What]. Use when [triggers]. [Capabilities].) with multiple natural trigger phrases and synonyms. |
+| **4** | Three-part pattern present. Good trigger phrases covering most common invocations.                                    |
+| **3** | Has triggers but missing capabilities section, or capabilities blended into "what" section.                           |
+| **2** | Few trigger phrases. Missing one or more parts of the pattern. Users likely won't discover it naturally.              |
+| **1** | No meaningful trigger phrases or structure. Skill unlikely to be invoked.                                             |
 
 **Evidence to look for**:
 
-- Trigger phrases in frontmatter description
-- Variety of phrasings (verbs, nouns, synonyms)
+- Three-part description: [What]. Use when [triggers]. [Capabilities].
+- Variety of phrasings (verbs, nouns, synonyms) in trigger section
 - Natural language patterns users would actually say
-- "Use when..." or similar guidance
+- Distinct capabilities sentence listing key features, tools, or outputs
 - Keywords matching user queries
 
 ## Calculating the Weighted Score

--- a/skills/tdd-cycle/SKILL.md
+++ b/skills/tdd-cycle/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: tdd-cycle
-description: >-
-  Enforces strict red-green-refactor TDD cycles with phase gates. Use when
-  doing TDD, test-driven development, red green refactor, write tests first,
-  test-first development, failing test, or make tests pass.
+description: Enforces strict red-green-refactor TDD cycles with phase gates. Use when doing TDD, test-driven development, writing tests first, or making failing tests pass. Manages cycle state, blocks premature implementation, and validates phase transitions.
 ---
 
 # TDD Cycle

--- a/skills/tech-debt/SKILL.md
+++ b/skills/tech-debt/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: tech-debt
-description: >-
-  Identifies, classifies, and prioritizes technical debt with a remediation
-  roadmap. Use when auditing technical debt, assessing code quality, analyzing
-  maintenance burden, inventorying legacy code, or asking what's slowing us down.
+description: Identifies, classifies, and prioritizes technical debt. Use when auditing technical debt, assessing code quality, analyzing maintenance burden, or asking what's slowing us down. Produces categorized inventory with severity rankings, remediation roadmap, and fix recommendations.
 ---
 
 # Technical Debt Analysis

--- a/skills/typescript-quality-gate/SKILL.md
+++ b/skills/typescript-quality-gate/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: typescript-quality-gate
-description: >-
-  Runs TypeScript/JavaScript code quality checks — formatting, linting, type
-  checking, and tests. Use when checking TypeScript or JavaScript quality,
-  linting with biome, or running tsc and bun test.
+description: Runs TypeScript/JavaScript code quality checks. Use when checking TypeScript or JavaScript quality, linting, or running tests. Covers formatting and linting with biome, type checking with tsc, and test execution with bun test.
 ---
 
 # TypeScript Quality Gate

--- a/skills/vc-ship/SKILL.md
+++ b/skills/vc-ship/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: vc-ship
-description: >-
-  Automates end-to-end git workflows from branch creation through PR
-  submission. Organizes changes into atomic commits with clean history and
-  quality checks. Use when shipping code, preparing changes for review,
-  committing and pushing, creating pull requests, cleaning up commit
-  history, organizing commits, or making a PR.
+description: Automates end-to-end git workflows from branch creation through PR submission. Use when shipping code, preparing changes for review, committing and pushing, or creating pull requests. Organizes atomic commits, cleans history, runs quality checks, and manages branch lifecycle.
 ---
 
 ## Reference Files

--- a/skills/vc-sync/SKILL.md
+++ b/skills/vc-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vc-sync
-description: Syncs local repository by switching to main, pulling latest from remote, and cleaning merged branches. Use when syncing repo, pulling latest, refreshing branches, updating from remote, cleaning up after merging PRs, fetching and merging, updating main, or pruning stale branches.
+description: Syncs local repository with remote. Use when syncing repo, pulling latest, refreshing branches, updating from remote, or cleaning up after merging PRs. Switches to main, pulls latest, and prunes merged branches.
 ---
 
 ## Purpose

--- a/skills/walkthrough/SKILL.md
+++ b/skills/walkthrough/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: walkthrough
-description: Reads source code and produces a linear, executable walkthrough document using showboat. Use when explaining how code works in detail, creating code walkthroughs, documenting a codebase, walking through a repository, onboarding to a new project, understanding unfamiliar code, giving a code tour, or explaining how a repo works.
+description: Reads source code and produces a linear, executable walkthrough document. Use when explaining how code works, creating code walkthroughs, onboarding to a project, or giving a code tour. Generates structured showboat documents with annotated code paths.
 ---
 
 Read the source and produce a linear walkthrough that explains how the code works in detail. Use showboat to build an executable `walkthrough.md` in the repo root. Include concerns about code quality and adherence to community standards.


### PR DESCRIPTION
## Summary

- Restructured all 23 skill descriptions to follow `[What it does]. Use when [triggers]. [Key capabilities].`
- Updated convention docs (CLAUDE.md, skill-creator, cc-lint, skill-quality, skill-improve) to codify and enforce the pattern
- Net reduction of 37 lines by eliminating redundant trigger phrases and normalizing YAML format

## Test plan

- [ ] Verify skill descriptions render correctly in skill list
- [ ] Run `/cc-lint` to confirm descriptions pass validation
- [ ] Run `/skill-quality` on a sample skill to confirm scoring rubric uses updated criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)