### PR TITLE
feat: deny pip/python and npm/node in favor of uv and bun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,25 +25,14 @@ logs/
 .mcp.json
 .claude/settings.local.json
 
-# Marketplace cache
+# Plugin and marketplace cache
 skills/.marketplace/
 
-# Symlinked skills (installed via `npx skills add -g`)
-skills/brainstorming
-skills/defuddle
-skills/executing-plans
-skills/writing-plans
-skills/find-skills
-
-# My local Claude config for the Claude config
+# Local data (not part of the customization repo)
 .claude/
 cache/
 paste-cache/
 tasks/
 sessions/
-learning/
 usage-data/
 backups/
-reflections/
-mcp-needs-auth-cache.json
-readout-*

--- a/settings.json
+++ b/settings.json
@@ -61,7 +61,17 @@
       "Read(~/.kube/**)",
       "Read(~/.npmrc)",
       "Read(~/.pypirc)",
-      "Read(~/Library/Keychains/**)"
+      "Read(~/Library/Keychains/**)",
+      "Bash(pip:*)",
+      "Bash(pip3:*)",
+      "Bash(python:*)",
+      "Bash(python3:*)",
+      "Bash(node:*)",
+      "Bash(npm:*)",
+      "Bash(npx:*)",
+      "Bash(yarn:*)",
+      "Bash(pnpm:*)",
+      "Bash(pnpx:*)"
     ],
     "defaultMode": "default"
   },

--- a/skills/pre-release/SKILL.md
+++ b/skills/pre-release/SKILL.md
@@ -31,7 +31,7 @@ Run these in parallel:
 
 Run these in parallel:
 
-5. **All checks pass** — Run the project's check command (`bun run check`, `npm run check`, `go vet`, etc.). Detect the correct command from package.json scripts, Makefile, Taskfile, or similar.
+5. **All checks pass** — Run the project's check command (`bun run check`, `go vet`, `uv run check`, etc.). Detect the correct command from package.json scripts, Makefile, Taskfile, or similar.
 6. **Tests pass** — Run the project's test command (`bun test`, `go test ./...`, `pytest`, etc.).
 7. **Build succeeds** — Run the project's build command. For Obsidian plugins: verify `main.js`, `styles.css`, and `manifest.json` exist after build.
 8. **Full validation** — If the project has a `validate` script, run it. This typically combines multiple checks.
@@ -49,7 +49,7 @@ Run these in parallel:
 ### Phase 4: CI & GitHub
 
 12. **CI passing on main** — `gh run list --branch main --limit 1` should show a successful run. If the latest run failed, report which jobs failed.
-13. **No critical/high vulnerabilities** — Run the project's audit command (`bun audit --audit-level=critical`, `npm audit`, etc.). Warn on high, block on critical.
+13. **No critical/high vulnerabilities** — Run the project's audit command (`bun audit --audit-level=critical`, `uv pip audit`, etc.). Warn on high, block on critical.
 
 ### Phase 5: Release Readiness
 


### PR DESCRIPTION
## Summary

- Adds deny rules in `settings.json` for `pip`, `pip3`, `python`, `python3`, `node`, `npm`, `npx`, `yarn`, `pnpm`, and `pnpx`
- Updates `pre-release` skill to reference `uv`/`bun` instead of `npm`
- Cleans up stale `.gitignore` entries (removed symlinked skills, consolidated comments)

## Test plan

- [x] Verify `uv run python`, `uv add`, `uvx` still work (allowed)
- [x] Verify `bun`, `bunx` still work (allowed)
- [x] Verify `pip install`, `npm install`, `python3` are blocked (denied)