### PR TITLE
fix(session-review): remove redundant heading from output template

### DIFF
--- a/skills/session-review/assets/output-templates.md
+++ b/skills/session-review/assets/output-templates.md
@@ -3,8 +3,6 @@
 ## Full Reflection Format
 
 ```markdown
-# Session Reflection: [Date]
-
 ## Overview
 
 **Objectives**: What we set out to do


### PR DESCRIPTION
## Summary

- Remove the `# Session Reflection: [Date]` heading from the full reflection output template
- The date-stamped heading duplicates what Obsidian already provides via note title and properties

## Testing

- [x] Verify session-review output no longer includes redundant heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)