### PR TITLE
feat(cc-lint): add project-aware scoping

### DIFF
--- a/skills/cc-lint/SKILL.md
+++ b/skills/cc-lint/SKILL.md
@@ -15,6 +15,19 @@ Detailed evaluation guidance:
 
 ---
 
+## Scoping
+
+This skill scopes to the **current working directory** (the project root where Claude Code was launched):
+
+1. **Determine project root** — Use the current working directory as the project root
+2. **Locate `.claude/`** — Look for `<project-root>/.claude/` as the customization directory
+3. **Locate `settings.json`** — Check `<project-root>/.claude/settings.json` for integration validation
+4. **Use project-relative paths** — All file references in findings and reports should use paths relative to the project root
+
+When the project root _is_ `~/.claude/` (e.g., the claude-code-setup repo), the customization directory is the project root itself. Otherwise, customizations live in `<project-root>/.claude/`.
+
+If a specific file or directory is passed as an argument, lint that target directly instead of scanning the whole project.
+
 ## Focus Areas
 
 - **YAML Frontmatter Validation** - Required fields, syntax correctness, field values

--- a/skills/cc-lint/references/evaluation-process.md
+++ b/skills/cc-lint/references/evaluation-process.md
@@ -2,16 +2,27 @@
 
 This document describes the step-by-step process for evaluating Claude Code customizations.
 
+## Step 0: Determine Scope
+
+Resolve the customization directory before scanning:
+
+1. Use the current working directory as the **project root**
+2. If project root is `~/.claude/`, the customization directory is the project root itself
+3. Otherwise, the customization directory is `<project-root>/.claude/`
+4. If a specific file or directory was passed as an argument, use that directly
+
+All subsequent paths are relative to the resolved customization directory.
+
 ## Step 1: Identify Extension Type
 
 Determine what type of customization is being evaluated:
 
-- Agent (in `~/.claude/agents/` or `.claude/agents/`)
-- Command (in `~/.claude/commands/` or `.claude/commands/`)
-- Skill (in `~/.claude/skills/` or `.claude/skills/`)
-- Hook (in `~/.claude/hooks/` or `.claude/hooks/`)
-- Output-Style (in `~/.claude/output-styles/` or `.claude/output-styles/`)
-- Setup (entire .claude/ configuration)
+- Agent (in `agents/`)
+- Command (in `commands/`)
+- Skill (in `skills/`)
+- Hook (in `hooks/`)
+- Output-Style (in `output-styles/`)
+- Setup (entire customization directory)
 
 ## Step 2: Apply Type-Specific Validation
 
@@ -59,7 +70,7 @@ Use Read tool to examine the file(s), then check:
 
 ## Step 3: Check Integration with Settings
 
-Use Read to examine `~/.claude/settings.json`:
+Use Read to examine `settings.json` in the resolved customization directory:
 
 1. Verify hooks are registered if needed
 2. Check for permission conflicts


### PR DESCRIPTION
## Summary

- cc-lint now resolves the customization directory from the current working directory instead of assuming `~/.claude/`
- Added Scoping section to SKILL.md and Step 0 to evaluation-process.md
- Replaced hardcoded `~/.claude/` paths with project-relative paths in type identification and settings validation

## Test plan

- [x] Invoke `/cc-lint` from `~/.claude/` — should lint the repo root
- [x] Invoke `/cc-lint` from another project — should target `<project>/.claude/`
- [x] Pass a specific skill path as argument — should lint that target directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)