### PR TITLE
chore: codebase maintenance — prune, lint fixes, hook improvements

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -50,6 +50,7 @@ Skills follow the [Agent Skills specification](https://agentskills.io/specificat
 **Session lifecycle:**
 
 - `load-session-context.sh` — Loads context on SessionStart
+- `log-event.sh` — Logs hook events with timestamp, event name, and session ID (async, with 5MB rotation)
 
 **Status line:**
 
@@ -80,7 +81,7 @@ Skills follow the [Agent Skills specification](https://agentskills.io/specificat
 ### Shipping and syncing
 
 - `/vc-ship` (skill) — Branch management, atomic commits, history cleanup, PR creation
-- `/vc-sync` (command) — Switch to main, pull remote, clean merged branches
+- `/vc-sync` (skill) — Switch to main, pull remote, clean merged branches
 
 ### Manual formatting
 

--- a/hooks/log-event.sh
+++ b/hooks/log-event.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
-input=$(cat)
-event=$(echo "$input" | jq -r '.hook_event_name // "unknown"')
-session=$(echo "$input" | jq -r '.session_id // "unknown"')
+logfile="$HOME/.claude/logs/hook-events.log"
+input=$(cat) || true
+event=$(echo "$input" | jq -r '.hook_event_name // "unknown"' 2>/dev/null) || event="unknown"
+session=$(echo "$input" | jq -r '.session_id // "unknown"' 2>/dev/null) || session="unknown"
 
-echo "$(date -Iseconds) $event $session" >>"$HOME/.claude/logs/hook-events.log"
+# Rotate if log exceeds 5MB
+if [[ -f "$logfile" ]] && [[ $(stat -f%z "$logfile" 2>/dev/null || echo 0) -gt 5242880 ]]; then
+  mv "$logfile" "${logfile}.$(date +%Y%m%d)"
+fi
+
+echo "$(date -Iseconds) $event $session" >>"$logfile"
 
 exit 0

--- a/settings.json
+++ b/settings.json
@@ -172,16 +172,6 @@
             "timeout": 5
           }
         ]
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/log-event.sh",
-            "timeout": 5,
-            "async": true
-          }
-        ]
       }
     ],
     "PermissionRequest": [
@@ -204,16 +194,6 @@
             "type": "command",
             "command": "~/.claude/hooks/auto-format.sh",
             "timeout": 10
-          }
-        ]
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/log-event.sh",
-            "timeout": 5,
-            "async": true
           }
         ]
       }
@@ -360,7 +340,8 @@
     "pyright-lsp@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
     "superpowers@superpowers-dev": true,
-    "obsidian@obsidian-skills": true
+    "obsidian@obsidian-skills": true,
+    "swift-lsp@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "claude-plugins-official": {

--- a/skills/go-quality-gate/SKILL.md
+++ b/skills/go-quality-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-quality-gate
-description: Runs Go code quality checks. Use when checking Go code quality, linting, running checks, or validating a Go project. Covers formatting with gofmt, static analysis with go vet, and test execution.
+description: Runs Go code quality checks. Use when checking Go code quality, linting, running checks, or validating a Go project. Covers formatting with gofmt, static analysis with go vet, and test execution with go test.
 ---
 
 # Go Quality Gate

--- a/skills/let-fate-decide/SKILL.md
+++ b/skills/let-fate-decide/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: let-fate-decide
 description: "Draws 4 Tarot cards using os.urandom() to inject entropy into planning. Use when prompts are vague, the user says 'let fate decide', makes Yu-Gi-Oh references, demonstrates indifference about approach, or multiple approaches are equally valid. Interprets the spread to generate actionable next steps from randomized input."
-allowed-tools:
-  - Bash
-  - Read
-  - Grep
-  - Glob
 ---
 
 # Let Fate Decide

--- a/skills/md-audit/SKILL.md
+++ b/skills/md-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: md-audit
-description: Audits and improves CLAUDE.md files by scanning repositories. Use for CLAUDE.md maintenance and optimization or when reviewing what project instructions should contain. Evaluates quality against templates, outputs scored reports, and applies targeted updates.
+description: Audits and improves CLAUDE.md files by scanning repositories. Use when maintaining CLAUDE.md files, optimizing project instructions, or reviewing what project instructions should contain. Evaluates quality against templates, outputs scored reports, and applies targeted updates.
 ---
 
 **This skill can write to CLAUDE.md files.** After presenting a quality report and getting user approval, it updates CLAUDE.md files with targeted improvements.

--- a/skills/pre-release/SKILL.md
+++ b/skills/pre-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pre-release
-description: Validates a project is ready to tag and ship. Use before tagging a release, cutting a version, shipping a package, or when asking "are we ready to release?" Checks repo hygiene, CI status, docs, version sync, and build verification.
+description: Validates a project is ready to tag and ship. Use when tagging a release, cutting a version, shipping a package, or asking "are we ready to release?" Checks repo hygiene, CI status, docs, version sync, and build verification.
 ---
 
 # Pre-Release Gate

--- a/skills/session-review/SKILL.md
+++ b/skills/session-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-review
-description: Analyzes the current session to extract patterns, preferences, and learnings. Use for session retrospectives, debriefs, post-mortems, or reflecting on insights worth remembering. Produces structured reviews capturing what worked, what to improve, and actionable takeaways.
+description: Analyzes the current session to extract patterns, preferences, and learnings. Use when running session retrospectives, debriefs, post-mortems, or reflecting on insights worth remembering. Produces structured reviews capturing what worked, what to improve, and actionable takeaways.
 ---
 
 # Session Review


### PR DESCRIPTION
## Summary

- Remove PreToolUse/PostToolUse event logging (88% of log volume, minimal signal)
- Add 5MB log rotation and fix jq error handling in `log-event.sh`
- Fix 5 cc-lint warnings across skill descriptions and frontmatter
- Sync CLAUDE.md: add `log-event.sh` docs, fix `vc-sync` label (command → skill)
- Enable `swift-lsp` plugin
- Prune stale `Skill(cc-plan)` from `settings.local.json`

Also applied outside repo (not in this PR):
- Pruned 13 stale entries from `~/.claude.json` (7 projects + 6 githubRepoPaths)
- Fixed dotfiles `CLAUDE.md` stale refs (`.gituprc`, `fish_prompt`)

## Test plan

- [ ] Verify `settings.json` validates against schema
- [ ] Confirm hook logging still works for non-tool events
- [ ] Spot-check skill descriptions pass cc-lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)