### PR TITLE
fix(vc-ship): resolve eval-surfaced gaps

### DIFF
--- a/skills/vc-ship/references/commit-format.md
+++ b/skills/vc-ship/references/commit-format.md
@@ -8,9 +8,11 @@ The first line is the most important — it appears in logs, PRs, and everywhere
 
 1. **≤72 characters** (50 ideal, 72 max)
 2. **Imperative mood**: "Add feature" not "Added" or "Adds"
-3. **Capitalize** first word
+3. **Capitalize** first word (after any prefix — see below)
 4. **No period** at the end
 5. **Be specific**: describe what changed, not that something changed
+
+**Conventional commit prefixes**: If the project uses prefixes like `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`, apply them. The capitalization rule applies to the first word after the prefix (e.g., `feat: Add user profile endpoint`). Check `git log --oneline -5` for the project's prevailing style.
 
 **Why imperative?** Git uses it natively ("Merge branch", "Revert 'Add X'"). Match that style.
 

--- a/skills/vc-ship/references/workflow-phases.md
+++ b/skills/vc-ship/references/workflow-phases.md
@@ -14,6 +14,8 @@ See **[phase-0-protocol.md](phase-0-protocol.md#detection-order)** for the full 
 
 **Goal**: Thoroughly understand the current repository state and changes.
 
+**Clean tree shortcut**: If the working tree is clean (nothing to stage or commit) but unpushed commits exist on the current branch, skip Phases 2-4 and proceed directly to Phase 5 (quality review). The existing commits are the work to ship.
+
 **Steps**:
 
 1. Run these commands in parallel:
@@ -59,13 +61,16 @@ See **[phase-0-protocol.md](phase-0-protocol.md#detection-order)** for the full 
 **Steps**:
 
 1. Analyze all changed files
-2. Group files by the categories above
-3. Within each category, identify sub-groups if changes are independent
-4. Create a commit plan showing:
+2. Re-inspect individual diffs (`git diff <file>`) when grouping is ambiguous — especially for config files that may be coupled to specific features
+3. Group files by the categories above
+4. Within each category, identify sub-groups if changes are independent
+5. Create a commit plan showing:
    - Each proposed commit
    - Files included
    - Brief description of what the commit will represent
-5. Present plan to user for approval/adjustment
+6. Present plan to user for approval/adjustment
+
+**Cross-cutting documentation**: When a single file (e.g., README) references changes from multiple feature commits, prefer a trailing docs commit rather than splitting the file across commits with `git add -p`. This keeps each feature commit focused and avoids partial documentation states.
 
 **Use TaskCreate** to track each commit as a task if there are 3+ commits. Update task status as you create each one.
 


### PR DESCRIPTION
## Summary

- Ran skill-creator eval loop against vc-ship (6 subagent runs, 3 test cases)
- All runs independently flagged the same 4 gaps — this PR fixes the high and medium priority ones

## Changes

**commit-format.md**
- Add conventional commit prefix guidance (`feat:`, `fix:`, etc.) and clarify capitalization rule applies after the prefix

**workflow-phases.md**
- Document "clean tree shortcut" — skip Phases 2-4 when unpushed commits already exist (the "ship it" path)
- Add diff re-inspection step in Phase 2 for ambiguous config file grouping
- Add cross-cutting documentation guidance (trailing docs commit when a file spans multiple features)

## Eval results

| | with_skill | without_skill | delta |
|---|---|---|---|
| Pass rate | 100% | 76% | +24% |
| Avg tokens | 30,748 | 14,070 | +16,678 |

## Test plan

- [ ] Invoke `/vc-ship` with "ship it" on a clean feature branch — verify it skips to Phase 5
- [ ] Invoke `/vc-ship` with mixed changes — verify Phase 2 asks clarifying questions about config grouping
- [ ] Verify commit messages with `feat:` prefix pass Phase 5 capitalization check

🤖 Generated with [Claude Code](https://claude.com/claude-code)