### PR TITLE
refactor(pre-release): optimize for Obsidian plugin release workflow

### DIFF
--- a/skills/pre-release/SKILL.md
+++ b/skills/pre-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pre-release
-description: Validates a project is ready to tag and ship. Use when tagging a release, cutting a version, shipping a package, or asking "are we ready to release?" Checks repo hygiene, CI status, docs, version sync, and build verification.
+description: Validates a project is ready to tag and ship. Use when tagging a release, cutting a version, shipping a package, or asking "are we ready to release?" Checks repo hygiene, CI status, docs, version sync, and build verification. Optimized for Obsidian plugins with fallback detection for other project types.
 ---
 
 # Pre-Release Gate
@@ -12,7 +12,15 @@ Systematic verification that a project is ready to tag and release. Runs every c
 Invoke with an optional version argument:
 
 - `/pre-release` — detect version from package.json, manifest.json, or similar
-- `/pre-release 1.0.1` — verify against a specific expected version
+- `/pre-release 1.2.0` — verify against a specific expected version
+
+## Project Detection
+
+Detect the project type from the root directory before running checks. This determines which commands and files to verify.
+
+**Obsidian plugin** (primary path): `manifest.json` contains an `id` field and `obsidian` appears in devDependencies. Expect `package.json`, `manifest.json`, `versions.json`, and build artifacts `main.js`, `styles.css`.
+
+**Other projects**: Detect from `go.mod` (Go), `pyproject.toml` (Python), `Cargo.toml` (Rust), or fall back to generic checks. Adapt commands accordingly — the checklist structure stays the same, but the specific commands change.
 
 ## Checklist
 
@@ -22,69 +30,60 @@ Run all checks from the project root. Use **parallel** tool calls where checks a
 
 Run these in parallel:
 
-1. **Clean working tree** — `git status` must show no uncommitted changes (staged or unstaged). Untracked files are acceptable only if they're in `.gitignore`.
-2. **On main/default branch** — Confirm the current branch is `main` (or the repo's default). Releases should be tagged from the default branch.
+1. **Clean working tree** — `git status` must show no uncommitted changes (staged or unstaged). Untracked files are acceptable only if covered by `.gitignore`.
+2. **On default branch** — Confirm the current branch is `main` (or the repo's default). Releases should be tagged from the default branch.
 3. **Up to date with remote** — `git fetch origin` then compare `HEAD` with `origin/main`. Warn if behind.
 4. **No open PRs targeting main** — `gh pr list --base main --state open` should be empty or the user should acknowledge pending PRs.
 
-### Phase 2: Quality Gates
+### Phase 2: Quality & Build
 
-Run these in parallel:
+Run the project's validation pipeline. For Obsidian plugins, this is typically a single command that covers multiple concerns.
 
-5. **All checks pass** — Run the project's check command (`bun run check`, `go vet`, `uv run check`, etc.). Detect the correct command from package.json scripts, Makefile, Taskfile, or similar.
-6. **Tests pass** — Run the project's test command (`bun test`, `go test ./...`, `pytest`, etc.).
-7. **Build succeeds** — Run the project's build command. For Obsidian plugins: verify `main.js`, `styles.css`, and `manifest.json` exist after build.
-8. **Full validation** — If the project has a `validate` script, run it. This typically combines multiple checks.
+5. **Validate** — Run the project's validate script if one exists (`bun run validate`, `make validate`, etc.). For Obsidian plugins, this typically runs type checking, linting, build, and verifies artifacts exist. If no validate script exists, run check/lint, test, and build as separate steps.
+6. **Tests pass** — Run the project's test command (`bun test`, `go test ./...`, `pytest`, etc.). Skip if the validate script already ran tests.
+7. **Walkthrough current** — If a `walkthrough.md` exists, run `uvx showboat verify walkthrough.md` to confirm code blocks match current source. Skip if no walkthrough exists.
+8. **Dependency audit** — Run the project's audit command (`bun audit --audit-level=critical`, `uv pip audit`, `go vuln check`, etc.). Warn on high severity, block on critical.
 
-### Phase 3: Documentation & Versioning
+### Phase 3: Release Readiness
 
-9. **CHANGELOG exists and mentions the target version** — Check that `CHANGELOG.md` (or equivalent) has an entry for the version being released.
-10. **Version consistency** — All version-bearing files must agree. Common files to check:
-    - `package.json` → `version`
-    - `manifest.json` → `version` (Obsidian plugins)
-    - `versions.json` — must have an entry for the target version (Obsidian plugins)
-    - `Cargo.toml`, `pyproject.toml`, `go.mod` — as applicable
-11. **Walkthrough / docs current** — If a `walkthrough.md` exists, run `uvx showboat verify walkthrough.md` to confirm code blocks match current source. Skip if no walkthrough exists.
-
-### Phase 4: CI & GitHub
-
-12. **CI passing on main** — `gh run list --branch main --limit 1` should show a successful run. If the latest run failed, report which jobs failed.
-13. **No critical/high vulnerabilities** — Run the project's audit command (`bun audit --audit-level=critical`, `uv pip audit`, etc.). Warn on high, block on critical.
-
-### Phase 5: Release Readiness
-
-14. **Tag doesn't already exist** — `git tag -l <version>` must be empty.
-15. **Previous release tag exists** — Verify there's at least one prior tag (sanity check for first-time releases).
-16. **Diff since last tag** — Show `git log --oneline <last-tag>..HEAD` so the user can review what's included.
+9. **Version consistency** — All version-bearing files must agree on the target version:
+   - `package.json` → `version`
+   - `manifest.json` → `version` (Obsidian plugins)
+   - `versions.json` — must have an entry mapping the target version to a `minAppVersion` (Obsidian plugins)
+   - `Cargo.toml`, `pyproject.toml`, `go.mod` — as applicable
+     If versions disagree, suggest running the version-bump script (e.g., `bun run version`) if one exists.
+10. **CHANGELOG entry** — `CHANGELOG.md` (or equivalent) must have a section for the target version.
+11. **CI passing on main** — `gh run list --branch main --limit 1` should show a successful run. If the latest run failed, report which jobs failed.
+12. **Tag available** — `git tag -l <version>` must be empty (tag doesn't already exist).
+13. **Previous release tag exists** — Verify there's at least one prior tag. For first releases, note this as informational rather than blocking.
+14. **Changes since last tag** — Show `git log --oneline <last-tag>..HEAD` so the user can review what's included.
 
 ## Output
 
 Present a summary table after all checks complete:
 
 ```text
-Pre-Release Gate: v1.0.1
-========================
+Pre-Release Gate: v2.0.0 (Obsidian plugin)
+===========================================
 
-| #  | Check                    | Status | Details                    |
-|----|--------------------------|--------|----------------------------|
-| 1  | Clean working tree       | PASS   |                            |
-| 2  | On default branch        | PASS   | main                       |
-| 3  | Up to date with remote   | PASS   |                            |
-| 4  | No open PRs              | WARN   | 1 open PR (#36)            |
-| 5  | Checks pass              | PASS   |                            |
-| 6  | Tests pass               | PASS   | 12 tests                   |
-| 7  | Build succeeds           | PASS   |                            |
-| 8  | Validation               | PASS   |                            |
-| 9  | CHANGELOG                | PASS   | 1.0.1 entry found          |
-| 10 | Version consistency      | FAIL   | package.json=1.0.0         |
-| 11 | Docs current             | PASS   | walkthrough verified        |
-| 12 | CI passing               | PASS   |                            |
-| 13 | No vulnerabilities       | PASS   |                            |
-| 14 | Tag available            | PASS   | 1.0.1 not yet tagged       |
-| 15 | Prior release exists     | PASS   | 1.0.0                      |
-| 16 | Changes since last tag   | INFO   | 8 commits                  |
+| #  | Check                  | Status | Details                        |
+|----|------------------------|--------|--------------------------------|
+| 1  | Clean working tree     | PASS   |                                |
+| 2  | On default branch      | PASS   | main                           |
+| 3  | Up to date with remote | PASS   |                                |
+| 4  | No open PRs            | WARN   | 1 open PR (#36)                |
+| 5  | Validate               | PASS   | types, lint, build, artifacts  |
+| 6  | Tests pass             | PASS   | 12 tests                       |
+| 7  | Walkthrough current    | PASS   | showboat verified              |
+| 8  | Dependency audit       | PASS   |                                |
+| 9  | Version consistency    | PASS   | 2.0.0 across all files         |
+| 10 | CHANGELOG entry        | PASS   | 2.0.0 section found            |
+| 11 | CI passing             | PASS   |                                |
+| 12 | Tag available          | PASS   | 2.0.0 not yet tagged           |
+| 13 | Prior release exists   | PASS   | 1.5.0                          |
+| 14 | Changes since last tag | INFO   | 8 commits                      |
 
-Result: BLOCKED (1 failure, 1 warning)
+Result: READY (0 failures, 1 warning)
 ```
 
 ### Status meanings
@@ -97,11 +96,13 @@ Result: BLOCKED (1 failure, 1 warning)
 
 ### After the gate
 
-If all checks pass (no FAIL status), ask the user if they want to proceed with tagging:
+If all checks pass (no FAIL status), ask the user if they want to proceed with tagging. The release workflow is tag-push — GitHub Actions handles building and publishing the release:
 
 ```bash
 git tag -a <version> -m "Release <version>"
 git push origin <version>
 ```
 
-If any check fails, list the failures and suggest fixes. Do not offer to tag.
+For Obsidian plugins, this triggers the release workflow which builds the plugin and creates a GitHub release with `main.js`, `styles.css`, and `manifest.json` as assets.
+
+If any check fails, list the failures and suggest specific fixes. Do not offer to tag.


### PR DESCRIPTION
## Summary

- Add project type detection with Obsidian plugin as primary path, fallback for Go/Python/Rust
- Consolidate 5 phases into 3 matching actual release flow: repo state, quality & build, release readiness
- Lean on `bun run validate` instead of duplicating quality/build checks
- Add walkthrough verification via showboat, version-bump awareness, Obsidian-specific after-gate guidance

## Test plan

- [x] Eval 1: Happy path — Obsidian plugin detected, all 14 checks run, correct version, showboat verified
- [x] Eval 2: Version mismatch — FAIL on consistency/CHANGELOG, suggests `bun run version`
- [x] Eval 3: Go fallback — detected as Go module, adapted commands, correct SKIPs
- [x] 100% assertion pass rate across all 3 evals (vs 83.8% baseline without skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)