### PR TITLE
chore(cc-automation-recommender): improve skill quality to production-ready

### DIFF
--- a/skills/cc-automation-recommender/SKILL.md
+++ b/skills/cc-automation-recommender/SKILL.md
@@ -1,6 +1,6 @@
 ---
 disable-model-invocation: true
-description: Analyzes a codebase and recommends Claude Code automations. Use when asking for automation recommendations, optimizing Claude Code setup, or setting up Claude Code for a project. Covers hooks, subagents, skills, plugins, and MCP servers.
+description: Analyzes a codebase and recommends Claude Code automations. Use when asking for automation recommendations, what automations to add, optimizing or configuring Claude Code setup, or setting up Claude Code for a new project. Covers hooks, subagents, skills, plugins, and MCP servers.
 ---
 
 **This skill is read-only.** It analyzes the codebase and outputs recommendations. It does NOT create or modify any files. Users implement the recommendations themselves or ask Claude separately to help build them.
@@ -49,6 +49,14 @@ Gather project context using Read, Glob, and Grep tools:
 | Docs patterns      | OpenAPI, JSDoc, docstrings                    | Documentation skills            |
 
 **If analysis yields few signals**: Fall back to recommending universal automations (context7 MCP, auto-format hooks, code-reviewer subagent) and use WebSearch to find recommendations specific to the detected language/runtime.
+
+**Web search guidance**: After identifying the project's primary language/framework, search for tool-specific automations not covered in the reference files. Example queries:
+
+- `"MCP server" <framework>` (e.g., `"MCP server" Rails`)
+- `Claude Code hooks <tool>` (e.g., `Claude Code hooks biome`)
+- `<framework> Claude Code plugin` (e.g., `Flutter Claude Code plugin`)
+
+Integrate web results with reference-based recommendations — web search fills gaps, not replaces the references.
 
 ### Phase 2: Generate Recommendations
 
@@ -150,4 +158,5 @@ See [output-template.md](assets/output-template.md#claude-code-automation-recomm
 | [subagent-templates.md](references/subagent-templates.md) | Subagent templates with model selection guide |
 | [plugins-reference.md](references/plugins-reference.md)   | Official plugin catalog                       |
 | [output-template.md](assets/output-template.md)           | Report formatting template                    |
+| [example-report.md](assets/example-report.md)             | Completed example report (Next.js + Supabase) |
 | [decision-framework.md](references/decision-framework.md) | When to recommend each type + config tips     |

--- a/skills/cc-automation-recommender/assets/example-report.md
+++ b/skills/cc-automation-recommender/assets/example-report.md
@@ -1,0 +1,74 @@
+# Example Report
+
+A completed recommendation report for a Next.js + Supabase SaaS application.
+
+---
+
+## Claude Code Automation Recommendations
+
+I've analyzed your codebase and identified the top automations for each category. Here are my top 1-2 recommendations per type:
+
+### Codebase Profile
+
+- **Type**: TypeScript / Node.js
+- **Framework**: Next.js 14 (App Router)
+- **Key Libraries**: Supabase, Stripe, TailwindCSS, Playwright
+
+---
+
+### MCP Servers
+
+#### context7
+
+**Why**: Your project uses Next.js, Supabase, Stripe, and TailwindCSS — context7 provides live documentation for all of these, reducing hallucinated APIs and outdated patterns.
+**Install**: `claude mcp add context7`
+
+#### Supabase MCP
+
+**Why**: You have `@supabase/supabase-js` in dependencies and 12 migration files — direct database access lets Claude query tables, inspect schemas, and debug auth flows without manual SQL.
+**Install**: `claude mcp add supabase -- npx -y @supabase/mcp-server-supabase@latest`
+
+---
+
+### Skills
+
+#### create-migration
+
+**Why**: You have 12 existing migrations following a timestamp-prefix convention. A skill ensures new migrations match the pattern and run validation.
+**Create**: `.claude/skills/create-migration/SKILL.md`
+**Invocation**: User-only (`disable-model-invocation: true`)
+
+#### project-conventions
+
+**Why**: Your codebase uses `Result<T, E>` patterns, barrel exports, and specific naming conventions that Claude should follow automatically.
+**Create**: `.claude/skills/project-conventions/SKILL.md`
+**Invocation**: Claude-only (`user-invocable: false`)
+
+---
+
+### Hooks
+
+#### Auto-format on Edit (Prettier + ESLint)
+
+**Why**: Found `.prettierrc.json` and `eslint.config.js` — auto-formatting on every edit keeps code consistent without manual runs.
+**Where**: `.claude/settings.json`
+
+#### Block .env edits
+
+**Why**: Found `.env`, `.env.local`, and `.env.production` — these contain Supabase keys and Stripe secrets that should never be modified by Claude.
+**Where**: `.claude/settings.json`
+
+---
+
+### Subagents
+
+#### security-reviewer
+
+**Why**: Your codebase handles Stripe payments (`app/api/webhooks/stripe/`), user auth (`lib/auth/`), and PII (`app/api/users/`) — a dedicated security reviewer catches OWASP vulnerabilities in these critical paths.
+**Where**: `.claude/agents/security-reviewer.md`
+
+---
+
+**Want more?** Ask for additional recommendations for any specific category (e.g., "show me more MCP server options" or "what other hooks would help?").
+
+**Want help implementing any of these?** Just ask and I can help you set up any of the recommendations above.

--- a/skills/cc-automation-recommender/references/hooks-patterns.md
+++ b/skills/cc-automation-recommender/references/hooks-patterns.md
@@ -4,6 +4,16 @@ Hooks automatically run commands in response to Claude Code events. They're idea
 
 **Note**: These are common patterns. Use web search to find hooks for tools/frameworks not listed here to recommend the best hooks for the user.
 
+## Contents
+
+- Auto-Formatting Hooks
+- Type Checking Hooks
+- Protection Hooks
+- Test Runner Hooks
+- Quick Reference: Detection → Recommendation
+- Notification Hooks
+- Hook Placement
+
 ## Auto-Formatting Hooks
 
 ### Prettier (JavaScript/TypeScript)

--- a/skills/cc-automation-recommender/references/subagent-templates.md
+++ b/skills/cc-automation-recommender/references/subagent-templates.md
@@ -4,6 +4,16 @@ Subagents are specialized Claude instances that run in parallel, each with their
 
 **Note**: These are common patterns. Design custom subagents based on the codebase's specific review and analysis needs.
 
+## Contents
+
+- Code Review Agents
+- Specialized Agents
+- Utility Agents
+- Quick Reference: Detection → Recommendation
+- Subagent Placement
+- Model Selection Guide
+- Tool Access Guide
+
 ## Code Review Agents
 
 ### code-reviewer


### PR DESCRIPTION
## Summary

- Add TOCs to `hooks-patterns.md` and `subagent-templates.md` (both >100 lines, per project conventions)
- Add completed example report (`assets/example-report.md`) for verification guidance
- Expand web search guidance with example queries in SKILL.md Phase 1
- Broaden trigger description with additional synonyms for discoverability

## Quality Score

- **Before**: 4.29 (Good)
- **After**: ~4.69 (Production Ready)

## Test plan

- [ ] Verify all markdown links resolve
- [ ] Run `bunx prettier --check` on changed files
- [ ] Invoke `/cc-automation-recommender` on a test project to confirm workflow

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)