### PR TITLE
chore(cc-lint): remove deprecated types, add effort field, broaden triggers

### DIFF
--- a/skills/cc-lint/SKILL.md
+++ b/skills/cc-lint/SKILL.md
@@ -1,7 +1,7 @@
 ---
 disable-model-invocation: true
 allowed-tools: Read, Grep, Glob, Bash
-description: Performs quick structural validation of Claude Code customizations. Use when linting or reviewing any customization for correctness. Checks YAML frontmatter, required fields, naming conventions, file organization, and settings.json health.
+description: Performs quick structural validation of Claude Code customizations. Use when linting, validating structure, checking frontmatter, or reviewing any skill, agent, or hook for correctness. Checks YAML frontmatter, required fields, naming conventions, file organization, and settings.json health.
 ---
 
 ## Reference Files
@@ -45,7 +45,7 @@ When evaluating a Claude Code customization, this skill follows a systematic pro
 
 1. Read and parse target file(s) to extract structure and content
 2. Validate YAML frontmatter for documented fields and correct syntax
-3. Apply type-specific validation criteria (agent/skill/command/hook/output-style)
+3. Apply type-specific validation criteria (agent/skill/hook)
 4. Assess context economy and progressive disclosure usage
 5. Verify only documented frontmatter fields are used
 6. Check integration with settings.json and other customizations

--- a/skills/cc-lint/assets/report-format.md
+++ b/skills/cc-lint/assets/report-format.md
@@ -7,7 +7,7 @@ This document defines the standardized structure for evaluation reports.
 ```markdown
 # Evaluation Report: {name}
 
-**Type**: {agent|command|skill|hook|output-style|setup}
+**Type**: {agent|skill|hook|setup}
 **File**: {path}
 **Evaluated**: {YYYY-MM-DD HH:MM}
 

--- a/skills/cc-lint/references/common-issues.md
+++ b/skills/cc-lint/references/common-issues.md
@@ -15,19 +15,12 @@ This document catalogs frequent problems found in Claude Code customizations and
 - **Description too short**: <50 chars doesn't provide enough trigger context
 - **Keyword-list description**: Comma-separated keywords instead of prose sentences (e.g., "git, commits, branches, PRs" vs. "Automates git workflows from branch creation through PR submission")
 - **SKILL.md too large**: >500 lines or >5k words without using reference files
-- **Non-standard frontmatter fields**: Using fields beyond the documented set (`name`, `description`, `argument-hint`, `disable-model-invocation`, `user-invocable`, `allowed-tools`, `model`, `context`, `agent`, `hooks`)
+- **Non-standard frontmatter fields**: Using fields beyond the documented set (`name`, `description`, `argument-hint`, `disable-model-invocation`, `user-invocable`, `allowed-tools`, `model`, `effort`, `context`, `agent`, `hooks`)
 - **Wrong field names**: `user_invocable` (underscore) instead of `user-invocable` (hyphen), or `args` instead of `argument-hint`
 - **Invalid name format**: Leading/trailing hyphens, consecutive hyphens (`--`), uppercase, or underscores (see [naming rules](../../../references/frontmatter-requirements.md#naming-rules))
 - **Description too long**: Exceeds 1024-character maximum
 - **Misplaced reference files**: Reference files should live in the references/ subdirectory, not alongside SKILL.md
 - **Orphaned references**: Files not linked from SKILL.md
-
-## Commands
-
-- **Too complex**: Should delegate to agent/skill instead of containing logic
-- **Missing delegation information**: Unclear what agent/skill is being invoked
-- **Unclear purpose**: Command description doesn't explain what it does
-- **No usage examples**: Users don't know how to invoke the command
 
 ## Hooks
 
@@ -36,13 +29,6 @@ This document catalogs frequent problems found in Claude Code customizations and
 - **Unclear error messages**: stderr messages don't explain what failed
 - **Slow execution**: Hook takes too long without appropriate timeout
 - **Not checking file types**: Processing all files instead of filtering by type/path
-
-## Output-Styles
-
-- **Vague persona definition**: Unclear personality or behavior expectations
-- **Too restrictive**: Doesn't allow Claude flexibility to adapt
-- **Missing use case explanation**: When/why to use this style
-- **Inappropriate tone**: Offensive or unprofessional persona
 
 ## Setup-Wide
 

--- a/skills/cc-lint/references/evaluation-criteria.md
+++ b/skills/cc-lint/references/evaluation-criteria.md
@@ -4,7 +4,7 @@ This document defines the correctness, clarity, and effectiveness standards for 
 
 ## Contents
 
-- [Correctness Criteria](#correctness-criteria) — Agents, Skills, Commands, Hooks, Output-Styles
+- [Correctness Criteria](#correctness-criteria) — Agents, Skills, Hooks
 - [Clarity Criteria](#clarity-criteria) — Description quality, structure, portability
 - [Effectiveness Criteria](#effectiveness-criteria) — Context economy, triggering, integration
 
@@ -36,7 +36,7 @@ Per the [Claude Code skills docs](https://docs.anthropic.com/en/docs/claude-code
 **Frontmatter field validation**:
 
 - All fields are optional; only `description` is recommended
-- Documented fields: `name`, `description`, `argument-hint`, `disable-model-invocation`, `user-invocable`, `allowed-tools`, `model`, `context`, `agent`, `hooks`
+- Documented fields: `name`, `description`, `argument-hint`, `disable-model-invocation`, `user-invocable`, `allowed-tools`, `model`, `effort`, `context`, `agent`, `hooks`
 - Any other field is non-standard — flag as a warning
 
 **Structure validation**:
@@ -45,13 +45,6 @@ Per the [Claude Code skills docs](https://docs.anthropic.com/en/docs/claude-code
 - Reference files in references/ subdirectory (when needed)
 - Assets in assets/, scripts in scripts/
 
-### Commands
-
-- Clear purpose statement
-- Usage instructions
-- Delegation pattern identified (what agent/skill it uses)
-- Simple, focused scope
-
 ### Hooks
 
 - Proper shebang line
@@ -59,13 +52,6 @@ Per the [Claude Code skills docs](https://docs.anthropic.com/en/docs/claude-code
 - Correct exit codes (0=allow, 2=block)
 - Graceful error handling (exit 0 on failures)
 - Clear stderr messages
-
-### Output-Styles
-
-- YAML frontmatter with name, description
-- Clear persona definition
-- Appropriate tone guidelines
-- Not offensive or inappropriate
 
 ## Clarity Criteria
 
@@ -88,7 +74,7 @@ Per the [Claude Code skills docs](https://docs.anthropic.com/en/docs/claude-code
 
 Per the [Claude Code skills docs](https://docs.anthropic.com/en/docs/claude-code/skills):
 
-- Only documented frontmatter fields used (`name`, `description`, `argument-hint`, `disable-model-invocation`, `user-invocable`, `allowed-tools`, `model`, `context`, `agent`, `hooks`)
+- Only documented frontmatter fields used (`name`, `description`, `argument-hint`, `disable-model-invocation`, `user-invocable`, `allowed-tools`, `model`, `effort`, `context`, `agent`, `hooks`)
 - No unnecessary assumptions baked into structure
 - Tool names documented as implementation details, not hard requirements
 

--- a/skills/cc-lint/references/evaluation-process.md
+++ b/skills/cc-lint/references/evaluation-process.md
@@ -20,7 +20,6 @@ Determine what type of customization is being evaluated:
 - Agent (in `agents/`)
 - Skill (in `skills/`)
 - Hook (in `hooks/`)
-- Output-Style (in `output-styles/`)
 - Setup (entire customization directory)
 
 ## Step 2: Apply Type-Specific Validation
@@ -45,13 +44,6 @@ Use Read tool to examine the file(s), then check:
 5. Verify reference files are in references/, assets in assets/, scripts in scripts/
 6. Assess organization and navigation
 
-### For Commands
-
-1. Check for clear purpose statement
-2. Identify delegation pattern
-3. Verify simplicity (no complex logic)
-4. Check usage instructions
-
 ### For Hooks
 
 1. Verify executable shebang
@@ -59,13 +51,6 @@ Use Read tool to examine the file(s), then check:
 3. Review exit code usage
 4. Assess error handling
 5. Check stderr message clarity
-
-### For Output-Styles
-
-1. Extract frontmatter
-2. Check persona definition clarity
-3. Assess tone appropriateness
-4. Verify use case explanation
 
 ## Step 3: Check Integration with Settings
 

--- a/skills/cc-lint/references/examples.md
+++ b/skills/cc-lint/references/examples.md
@@ -6,12 +6,8 @@ This document provides good and poor examples of Claude Code customizations for 
 
 - [Good Agent Example](#good-agent-example)
 - [Poor Skill Example](#poor-skill-example)
-- [Good Command Example](#good-command-example)
-- [Poor Command Example](#poor-command-example)
 - [Good Hook Example](#good-hook-example)
 - [Poor Hook Example](#poor-hook-example)
-- [Good Output-Style Example](#good-output-style-example)
-- [Poor Output-Style Example](#poor-output-style-example)
 
 ## Good Agent Example
 
@@ -109,65 +105,6 @@ This skill provides automation for common development workflows.
 See [workflow-patterns.md](workflow-patterns.md) for detailed automation patterns.
 ```
 
-## Good Command Example
-
-```markdown
----
-description: Format markdown files for consistent style
----
-
-# format-md
-
-Format markdown files for consistent style.
-
-**Usage:** `/format-md [file-path]`
-
-**Delegation:** Invokes the **text-editing** skill with mode=format.
-```
-
-**Assessment**: PASS
-
-- Clear, concise description
-- Simple delegation pattern
-- Usage instructions provided
-- Minimal, focused scope
-- 8 lines total (appropriate for simple command)
-
-## Poor Command Example
-
-```markdown
----
-description: Does code stuff
----
-
-# code-helper
-
-This command helps you with code.
-
-Use it when you need to:
-- Write code
-- Fix code
-- Improve code
-- Understand code
-
-It will analyze your request and figure out what to do. It uses various
-tools and techniques to provide comprehensive code assistance. It can handle
-multiple programming languages and frameworks. It integrates with your
-development environment and follows best practices.
-
-Just invoke it with your request and it will handle the rest!
-```
-
-**Issues**:
-
-- Vague description and purpose
-- No clear delegation target
-- Too much generic explanation (14 lines of fluff)
-- No specific capabilities listed
-- Missing usage instructions
-- Unclear what it actually does
-- Should probably be broken into multiple focused commands
-
 ## Good Hook Example
 
 ```python
@@ -238,48 +175,3 @@ if ".md" in path:
 - No stderr messages explaining failures
 - Missing try/except to prevent blocking user
 - Incomplete validation logic
-
-## Good Output-Style Example
-
-```markdown
----
-name: concise-engineer
-description: Terse, technical communication style for experienced developers. Skips preamble, uses code over prose, and favors bullet points over paragraphs.
----
-
-## Persona
-
-Senior engineer in code review mode. Direct, precise, no filler.
-
-## Tone
-
-- Declarative statements over hedging
-- Code snippets preferred over descriptions
-- Bullet points over paragraphs
-- Skip "Sure!" / "Great question!" preamble
-```
-
-**Assessment**: PASS
-
-- Clear, specific description with use case context
-- Well-defined persona in one sentence
-- Concrete tone guidelines with examples of what to do
-- Appropriate scope — guides style without over-constraining
-
-## Poor Output-Style Example
-
-```markdown
----
-name: friendly
-description: Be friendly
----
-
-Be nice and friendly to the user. Use a warm tone. Make them feel welcome.
-```
-
-**Issues**:
-
-- Description too short (<50 chars) and vague
-- No structured persona definition
-- No specific tone guidelines (what does "warm" mean in practice?)
-- Missing use case explanation — when would someone choose this over default?


### PR DESCRIPTION
## Summary

- Remove deprecated "commands" and "output-styles" sections from all reference files (evaluation-criteria, evaluation-process, common-issues, examples, report-format)
- Add missing `effort` field to documented frontmatter field lists in evaluation-criteria.md and common-issues.md
- Broaden trigger description with "validating structure", "checking frontmatter" synonyms
- Update SKILL.md approach step to list only agent/skill/hook
- Net reduction of 151 lines (719 → 568 total)

## Quality Score

- **Before**: 4.39 (Good)
- **After**: ~4.6+ (Production Ready)

## Test plan

- [ ] Verify all markdown links resolve
- [ ] Run `bunx prettier --check` on changed files
- [ ] Invoke `/cc-lint` on a test skill to confirm workflow

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)