### PR TITLE
chore(deps-audit): add ecosystem table and fallback guidance

### DIFF
--- a/skills/deps-audit/SKILL.md
+++ b/skills/deps-audit/SKILL.md
@@ -8,13 +8,22 @@ Audit this project's dependencies. If $ARGUMENTS are provided, scope the audit a
 
 ## 1. Detect ecosystem
 
-Identify which package managers are present (package.json, requirements.txt/pyproject.toml, go.mod, Cargo.toml, Gemfile, composer.json, etc.) and their lock files.
+Identify which package managers are present and their lock files.
+
+| Manifest                          | Ecosystem | Audit Tool       | Outdated Tool       |
+| --------------------------------- | --------- | ---------------- | ------------------- |
+| package.json                      | Node.js   | `npm audit`      | `npm outdated`      |
+| pyproject.toml / requirements.txt | Python    | `pip-audit`      | `pip list -o`       |
+| go.mod                            | Go        | `govulncheck`    | `go list -m -u`     |
+| Cargo.toml                        | Rust      | `cargo audit`    | `cargo outdated`    |
+| Gemfile                           | Ruby      | `bundle-audit`   | `bundle outdated`   |
+| composer.json                     | PHP       | `composer audit` | `composer outdated` |
 
 ## 2. Three-dimension audit
 
 Run each check using the ecosystem's native tooling:
 
-- **Vulnerabilities** — run the native audit tool (`npm audit`, `pip-audit`, `cargo audit`, `govulncheck`, `bundle-audit`, etc.); classify findings by severity (critical / high / medium / low)
+- **Vulnerabilities** — run the native audit tool (see table above); classify findings by severity (critical / high / medium / low). If a tool isn't installed, note it in the report and skip that dimension rather than failing.
 - **Outdated** — check for outdated dependencies; flag major version bumps separately from minor/patch; note packages more than 6 months behind latest
 - **Licenses** — identify dependency licenses; flag copyleft (GPL, AGPL) and unknown licenses against the project's own license
 


### PR DESCRIPTION
## Summary

- Add explicit ecosystem reference table mapping manifests to audit/outdated tools
- Add fallback guidance: skip dimension when native tool isn't installed rather than failing

## Quality Score

- **Before**: 4.47 (Good, borderline Production Ready)
- **After**: ~4.6+ (Production Ready)

## Test plan

- [ ] Run `bunx prettier --check` on changed file
- [ ] Invoke `/deps-audit` on a Node.js project to confirm workflow

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)