### PR TITLE
chore(go-quality-gate): add allowed-tools and broaden triggers

### DIFF
--- a/skills/go-quality-gate/SKILL.md
+++ b/skills/go-quality-gate/SKILL.md
@@ -1,5 +1,6 @@
 ---
-description: Runs Go code quality checks. Use when checking Go code quality, linting, running checks, or validating a Go project. Covers formatting with gofmt, static analysis with go vet, and test execution with go test.
+allowed-tools: Read, Bash, Glob
+description: Runs Go code quality checks. Use when checking Go code quality, linting, running checks, validating Go code, or running go checks. Covers formatting with gofumpt, static analysis with go vet, and test execution with go test.
 ---
 
 # Go Quality Gate


### PR DESCRIPTION
## Summary

- Add `allowed-tools: Read, Bash, Glob` for explicit tool restriction
- Add trigger synonyms ("validating Go code", "running go checks")
- Fix description to reference `gofumpt` (actual tool used) instead of `gofmt`

## Quality Score

- **Before**: 4.75 (Production Ready)
- **After**: ~4.85 (Production Ready, minor polish)

## Test plan

- [ ] Run `bunx prettier --check` on changed file
- [ ] Verify frontmatter parses correctly

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)