### PR TITLE
chore(quality-gates): add allowed-tools and broaden triggers

### DIFF
--- a/skills/python-quality-gate/SKILL.md
+++ b/skills/python-quality-gate/SKILL.md
@@ -1,5 +1,6 @@
 ---
-description: Runs Python code quality checks. Use when checking Python quality, linting, type checking, or running tests. Covers formatting and linting with ruff, type checking with mypy, and test execution with pytest.
+allowed-tools: Read, Bash, Glob
+description: Runs Python code quality checks. Use when checking Python quality, linting, type checking, running tests, validating Python code, or running python checks. Covers formatting and linting with ruff, type checking with mypy, and test execution with pytest.
 ---
 
 # Python Quality Gate

--- a/skills/typescript-quality-gate/SKILL.md
+++ b/skills/typescript-quality-gate/SKILL.md
@@ -1,5 +1,6 @@
 ---
-description: Runs TypeScript/JavaScript code quality checks. Use when checking TypeScript or JavaScript quality, linting, or running tests. Covers formatting and linting with biome, type checking with tsc, and test execution with bun test.
+allowed-tools: Read, Bash, Glob
+description: Runs TypeScript/JavaScript code quality checks. Use when checking TypeScript or JavaScript quality, linting, running tests, validating TypeScript code, or running TS/JS checks. Covers formatting and linting with biome, type checking with tsc, and test execution with bun test.
 ---
 
 # TypeScript Quality Gate


### PR DESCRIPTION
## Summary

- Add `allowed-tools: Read, Bash, Glob` to python-quality-gate and typescript-quality-gate
- Add trigger synonyms ("validating python/typescript code", "running checks")

## Quality Score

Both skills were already Production Ready (~4.75); this polishes to ~4.85.

## Test plan

- [ ] Run `bunx prettier --check` on changed files
- [ ] Verify frontmatter parses correctly

Closes #317, Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)