### PR TITLE
docs: restructure CLAUDE.md files and add hugo-cli skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,18 +1,29 @@
-# claude-code-setup
+# CLAUDE.md
 
-Claude Code customization repository: skills, agents, hooks, rules, and references.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## claude-code-setup
+
+Claude Code customization repository: skills, agents, hooks, and rules.
+
+> This repo **is** `~/.claude`, so two CLAUDE.md files apply when working here: `../CLAUDE.md` (global user instructions loaded in every project) and this file (project instructions for editing the harness itself). The global file defines principles and collaboration style; this file documents how the harness is laid out and maintained.
+
+**Where to edit what:**
+
+- Harness structure, conventions, or commands → this file (`.claude/CLAUDE.md`)
+- Cross-project principles or collaboration style → `../CLAUDE.md`
+- Auto-loaded global rules (language/tool guidance) → `rules/<topic>.md`
 
 ## Architecture
 
 Components live under `.claude/` in a flat layout:
 
-| Type       | Location                    | Trigger          |
-| ---------- | --------------------------- | ---------------- |
-| Skills     | `skills/<name>/SKILL.md`    | Auto-detected    |
-| Agents     | `agents/<name>.md`          | Auto or explicit |
-| Hooks      | `hooks/<name>.sh\|.py\|.js` | Lifecycle events |
-| Rules      | `rules/<name>.md`           | Path-matched     |
-| References | `references/<name>.md`      | Loaded by skills |
+| Type   | Location                    | Trigger              |
+| ------ | --------------------------- | -------------------- |
+| Skills | `skills/<name>/SKILL.md`    | Auto-detected        |
+| Agents | `agents/<name>.md`          | Auto or explicit     |
+| Hooks  | `hooks/<name>.sh\|.py\|.js` | Lifecycle events     |
+| Rules  | `rules/<name>.md`           | Auto-loaded globally |
 
 ## Conventions
 
@@ -28,60 +39,47 @@ Skills follow the [Claude Code skills documentation](https://docs.anthropic.com/
 - Description follows three-part pattern: **[What it does]. Use when [triggers]. [Key capabilities].** (200-500 chars recommended)
 - SKILL.md target: under 500 lines; use supporting files for depth (progressive disclosure)
 - Reference files exceeding 100 lines should include a `## Contents` TOC
-- Naming uses prefix conventions per `naming-conventions.md`: `cc-` for Claude Code meta-tools, `vc-` for version control, `md-` for CLAUDE.md operations, no prefix for general-purpose skills
+- Naming prefixes: `cc-` for Claude Code meta-tools, `vc-` for version control, `md-` for CLAUDE.md operations, no prefix for general-purpose skills
+
+### Agents
+
+Subagent definitions live in `agents/<name>.md` as a flat list (one file per agent). Frontmatter declares `name`, `description`, and optionally `tools`. Invoked via the Task tool or automatically when the description matches.
 
 ### Hooks
 
-- Configured in `settings.json`, not in frontmatter
-- Exit codes: 0 = allow, 2 = block
+Scripts live in `hooks/`; `settings.json` is the source of truth for wiring. Scripts are organized by role: **guards** (PreToolUse), **formatters** and **monitors** (PostToolUse), **session lifecycle** (SessionStart/Stop), and **status line** (`statusLine` config).
 
-**Guards (PreToolUse):**
+### Plugins
 
-- `validate-bash-commands.py` — Suggests dedicated tools when Bash invokes grep, find, cat, sed, or awk
-- `config-protection.sh` — Warns when editing linter/formatter config files (eslint, biome, prettier, tsconfig, etc.)
-- `prompt-injection-guard.py` — Detects prompt injection patterns in content being written to files
+Third-party plugins sync under `plugins/marketplaces/<source>/`. **These files are overwritten on update** — never treat them as editable source. Small local tweaks survive until the next sync; durable changes belong upstream.
 
-**Formatters (PostToolUse):**
+### Rules
 
-- `auto-format.sh` — Runs prettier/gofmt on Edit/Write automatically
-
-**Monitors (PostToolUse):**
-
-- `suggest-compact.sh` — Nudges compaction every ~30 tool calls
-- `context-monitor.sh` — Tracks context window usage and emits warnings at thresholds
-
-**Session lifecycle:**
-
-- `load-session-context.sh` — Loads context on SessionStart
-- `log-event.sh` — Logs hook events with timestamp, event, session ID, and per-event detail (async, 5MB rotation). InstructionsLoaded excluded (too noisy).
-
-**Status line:**
-
-- `statusline-command.sh` — Renders directory, git branch, model, and context % (configured via `statusLine` in settings.json, not a lifecycle hook)
+Every `.md` file in `rules/` is auto-loaded by the harness into each session's system prompt as global user instructions. There is no registration step — adding a new file in `rules/` adds global guidance on the next session. Edits to existing rule files take effect on the next session, not immediately in the current one. Scope edits here carefully: a change to `rules/git.md` affects every project, not just this repo.
 
 ### Naming
 
 - All component names: kebab-case, lowercase, hyphens only
 
-## Formatting and Linting
-
-- The auto-format hook handles Prettier on every Edit/Write — manual runs needed only for batch formatting
-
 ## Common Commands
 
-### Quality workflow
+### Formatting and linting
 
-- `/cc-review` — Single-pass lint + quality score + improvement recommendations for any customization
+The repo uses `go-task` (`taskfile.yml`) for all formatting and linting. Run `task` for format + lint, `task check` for lint-only (CI-safe, no writes). `taskfile.yml` is the authoritative source for exact commands; run `task --list` to see everything.
 
-### Shipping and syncing
+| Task                        | Tool               | Scope              |
+| --------------------------- | ------------------ | ------------------ |
+| `format:md` / `lint:md`     | prettier           | all `**/*.md`      |
+| `format:json` / `lint:json` | biome              | top-level `*.json` |
+| `format:sh` / `lint:sh`     | shfmt / shellcheck | `hooks/*.sh`       |
+| `format:py` / `lint:py`     | ruff               | `hooks/*.py`       |
 
-- `/vc-ship` (skill) — Branch management, atomic commits, history cleanup, PR creation
-- `/vc-sync` (skill) — Switch to main, pull remote, clean merged branches
+Skills live in `skills/`; discover them with `ls skills/` rather than relying on any hand-maintained list here. Slash commands referenced in this file (`/vc-ship`, `/cc-review`, etc.) are skills under `skills/`.
 
 ## Git Workflow
 
 - Use `/vc-ship` for the full 8-phase ship process (branch, analyze, organize, commit, cleanup, review, push, PR)
-- `.claude/` is gitignored but contains tracked files — always use `git add -f` for new files in this directory
+- The nested `.claude/` directory tracks normally; only `.claude/settings.local.json` is ignored (local per-machine permission overrides)
 
 ## Skill Rename Protocol
 
@@ -96,8 +94,6 @@ When renaming a skill:
 
 ## Evaluation-Driven Workflow
 
-When implementing fixes from evaluation reports, always verify each fix individually before moving to the next one. After all fixes are applied, run the full quality evaluation to confirm everything passes.
-
-After completing any skill-related changes (directory renames, frontmatter updates, structural modifications), automatically run the /cc-review evaluation to validate the changes.
-
-When running evaluations or quality checks, always output a summary of results even if the task appears complete. Never end a session mid-evaluation without reporting status.
+- When applying fixes from a `/cc-review` report, verify each fix individually before moving to the next
+- After all fixes are applied, re-run `/cc-review` to confirm the changes pass
+- After any skill-structural change (rename, frontmatter, directory layout), run `/cc-review` automatically

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Runtime state
-.claude/
 .compete/
 backups/
 debug/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,18 +2,16 @@
 
 ## Technical Environment
 
-- macOS on Apple M4 (MacBook Air, Mac Mini) and iOS/iPadOS (iPhone, iPad Pro)
+- macOS (Apple Silicon) and iOS/iPadOS
 - fish shell, ghostty, vscode, git, gh
 - Obsidian for knowledge management (vault: `notes`, ~2,400 notes)
 - Things for task management, Apple Notes, Documents folder (organized archive)
 
 ## Principles
 
-- Build on ideas constructively
 - Avoid duplication in naming and code
 - Choose the simplest solution
 - Ask permission once; don't repeatedly confirm
-- Assume good intentions; trust and collaborate
 - Start simple, split when necessary
 - Accept defaults first, deviate when justified
 - **Never invent technical details.** If something is unknown, stop and research it or say so.
@@ -24,18 +22,14 @@
 
 - Give honest technical judgment. Never be agreeable just to be nice.
 - Push back on disagreements. Cite technical reasons if available; gut feelings are valid too.
-- Speak up immediately when something is unknown or the task is over our heads.
 - Ask clarifying questions about intent, scope, and trade-offs before finalizing a plan
 - Don't assume — probe for the "why" behind the request. Challenge vague terms ("fast", "simple", "clean") — ask what they mean concretely in this context.
 - Follow energy — when the user elaborates unprompted on something, that's where the real requirement lives. Dig there first.
 - Never write code for a new feature or system until the user has replied "approved" (or equivalent affirmation) to a PRD draft
 
-## Tooling Defaults
-
-- Obsidian CLI plugins (e.g., metadator): each file must be opened before running commands on it — batch operations require iterating individually
-
 ## Workflow
 
+- Obsidian CLI plugins (e.g., metadator): each file must be opened before running commands on it — batch operations require iterating individually
 - Always merge PR before creating git tags. Never tag before merge — tags must point to the merged commit on the target branch.
 - When parallelizing work with sub-agents, limit concurrency to avoid API rate limits. Use batches of 3-5 parallel agents max, not 20+.
 - When editing deploy scripts or build scripts, do not add commands (like `mkdir`) without explicit user approval. Prefer minimal changes.

--- a/rules/verification.md
+++ b/rules/verification.md
@@ -4,3 +4,4 @@
 - "I'm confident" is not evidence — confidence requires proof
 - If you cannot verify a claim, say so explicitly
 - 3 failed attempts at the same fix → stop and escalate, don't keep guessing
+- When running evaluations or multi-step checks, always report a summary at the end — never end a session mid-evaluation without status

--- a/skills/hugo-cli/SKILL.md
+++ b/skills/hugo-cli/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: hugo-cli
+description: Translates plain-English requests about a Hugo static site into correct `hugo` CLI invocations so the user never has to know the flags. Use whenever the user is working in a Hugo project (hugo.yaml / hugo.toml / hugo.json present), mentions Hugo by name, asks to build, preview, serve, deploy, or scaffold a site, asks to create new posts or pages, wants to inspect drafts/future/expired content, or is debugging a Hugo build — even if they never type the word "hugo". Prefer this skill over guessing flags from memory; Hugo's flag surface changes between versions.
+allowed-tools: Bash, Read, Glob, Grep, Edit
+---
+
+# Hugo CLI
+
+The user should be able to say what they want in their own words ("start the preview with drafts showing", "make me a new post about X", "why is my post not showing up on the site"). Your job is to translate that into the correct `hugo` invocation, run it, and report back. The user does not want to learn the CLI — that's the whole point of this skill existing.
+
+## Before running anything
+
+1. **Confirm you are in a Hugo project.** Look for `hugo.yaml`, `hugo.toml`, `hugo.json`, or (legacy) `config.yaml`/`config.toml`/`config.json` in the working directory or a parent. If none exist, say so before running Hugo commands — you are probably in the wrong directory.
+
+2. **Check for a task wrapper.** If the project has a `Taskfile.yml` / `taskfile.yml` with Hugo-related targets (commonly `task dev`, `task build`, `task new`, `task check`, `task clean`), **prefer the wrapper over raw `hugo`**. The wrapper encodes the project's conventions (environment, flags, output dirs) and running raw `hugo` can produce different results. Read the Taskfile to learn what each target does before substituting.
+
+   Grep for `hugo` in `Taskfile.yml` to see which targets wrap it. If a target matches the user's intent, use it. Only fall back to raw `hugo` if no wrapper covers the need.
+
+3. **Verify the Hugo binary.** Run `hugo version` once per session if you have not already. Hugo's CLI has evolved (e.g., modules, deploy, segments) and the available commands depend on whether the build is `extended` and includes `withdeploy`. If a feature the user needs is missing from the installed binary, say so rather than invent flags.
+
+## Intent → command mapping
+
+This is a quick map of the most common user intents. For full flag details, read `references/commands.md`.
+
+| User says something like…                                            | Run                                                                                                           |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| "preview my drafts", "authoring server", "dev server with drafts"    | `hugo server -D` (add `-F` if they mention future-dated posts)                                                |
+| "see what visitors will see", "preview production", "start the site" | `hugo server` (no `-D` — shows only published content, closer to what ships)                                  |
+| "open it in my browser"                                              | `hugo server -O` (add `-D` if authoring)                                                                      |
+| "build the site for production"                                      | `hugo --minify` (or the project's `task build` if it exists)                                                  |
+| "build including drafts"                                             | `hugo -D --minify`                                                                                            |
+| "start a new hugo site", "scaffold a site", "set up a new site"      | `hugo new site <path>` (creates the directory skeleton; `--force` to populate a non-empty dir)                |
+| "create a new theme"                                                 | `hugo new theme <name>` (writes to `themes/<name>/`)                                                          |
+| "clean build output"                                                 | delete `public/` and `resources/_gen/` — Hugo has no `clean` subcommand; the project may provide `task clean` |
+| "make a new post about X"                                            | `hugo new content posts/<slug>.md` (the archetype sets title/date/draft)                                      |
+| "make a new page X" (not a post)                                     | `hugo new content <section>/<slug>.md`                                                                        |
+| "list my drafts"                                                     | `hugo list drafts`                                                                                            |
+| "what's scheduled?" / "future posts"                                 | `hugo list future`                                                                                            |
+| "what's expired?"                                                    | `hugo list expired`                                                                                           |
+| "show everything"                                                    | `hugo list all`                                                                                               |
+| "show me the resolved config"                                        | `hugo config` (add `--format yaml` if they prefer)                                                            |
+| "what's my Hugo version / environment"                               | `hugo env`                                                                                                    |
+| "deploy the site"                                                    | `hugo deploy` (requires `deployment` section in config — check first)                                         |
+| "convert front matter to YAML/TOML/JSON"                             | `hugo convert toYAML` / `toTOML` / `toJSON`                                                                   |
+| "add a module / theme as a module"                                   | `hugo mod get <path>` then `hugo mod tidy`                                                                    |
+| "update modules"                                                     | `hugo mod get -u ./...` then `hugo mod tidy`                                                                  |
+| "show module graph"                                                  | `hugo mod graph`                                                                                              |
+| "vendor modules"                                                     | `hugo mod vendor`                                                                                             |
+| "initialize as a module"                                             | `hugo mod init <module-path>`                                                                                 |
+
+## Key flags worth remembering
+
+These are the ones that map directly to user intent rather than machine details:
+
+- `-D, --buildDrafts` — include drafts (authoring workflow)
+- `-F, --buildFuture` — include posts with a future `date` / `publishDate`
+- `-E, --buildExpired` — include posts past their `expiryDate`
+- `--minify` — minify HTML/XML/JSON/CSS/JS on build (production)
+- `-e, --environment <name>` — e.g., `production`, `staging`; selects `config/<env>/` overrides
+- `-b, --baseURL <url>` — override `baseURL` for this build (useful for preview deploys)
+- `-p, --port <n>` — change dev server port (default 1313)
+- `--bind <addr>` — bind dev server to an interface (e.g., `0.0.0.0` for LAN access)
+- `-O, --openBrowser` — open browser on `hugo server` startup
+- `--gc` — garbage-collect unused cache entries after build
+- `--logLevel debug|info|warn|error` — raise verbosity when debugging
+- `--printPathWarnings` — surface duplicate target-path problems
+- `--printUnusedTemplates` — surface templates that were never rendered
+- `--templateMetrics --templateMetricsHints` — performance profiling for templates
+
+For anything not listed above — and especially for subcommand-specific flags — load `references/commands.md` rather than guessing.
+
+## Debugging Hugo builds
+
+When the user says "my page isn't showing up" or "the build is wrong", work through this in order before changing anything:
+
+1. **Is it a draft?** `hugo list drafts`. If yes, either remove `draft: true` from the front matter or build with `-D`.
+2. **Is it future-dated?** `hugo list future`. If yes, either adjust `date` / `publishDate` or build with `-F`.
+3. **Is it expired?** `hugo list expired`. Same remedy with `-E` or edit `expiryDate`.
+4. **Duplicate paths or overridden layouts?** Rebuild with `--printPathWarnings`.
+5. **Unused templates (suggests a naming mismatch)?** Rebuild with `--printUnusedTemplates`.
+6. **Environment overrides masking something?** `hugo config -e production` vs `hugo config` to diff resolved values.
+7. **Module resolution?** `hugo mod graph` to confirm the expected modules are wired in.
+
+The goal is to let the CLI tell you what's wrong rather than reading templates or content files blind.
+
+## Running commands responsibly
+
+- `hugo server` is **long-running**. Start it in the background (or tell the user to run it) rather than blocking on it. Report the URL (`http://localhost:1313/` by default) and how to stop it.
+- `hugo deploy` pushes to real infrastructure. Always `--dryRun` first if the user has not explicitly approved a real deploy in this session, and surface the dry-run diff before running for real.
+- `hugo mod get -u` changes `go.mod` and lockfiles. Run `hugo mod tidy` after, and show the diff.
+- Never pass `--panicOnWarning` unless the user asked for strict mode — it turns warnings into hard failures.
+
+## Reporting back
+
+After running a command, tell the user:
+
+- What you ran (the literal command, so they can re-run it themselves)
+- What it produced (counts from the build summary, the dev URL, files created, etc.)
+- Any warnings worth attention
+
+Keep it terse. The user did not ask to learn Hugo — they asked for a result.
+
+## Reference files
+
+- `references/commands.md` — full per-subcommand flag reference (root/build, server, new, list, config, mod, deploy, convert, env, gen, import), global flags, and version/feature gotchas. Load this when SKILL.md does not cover the flag you need, when debugging a subcommand-specific issue, or when the user asks about a command not in the intent table above.

--- a/skills/hugo-cli/references/commands.md
+++ b/skills/hugo-cli/references/commands.md
@@ -1,0 +1,262 @@
+# Hugo CLI Reference
+
+Detailed per-command reference for `hugo` v0.160+ (extended, with-deploy). Load this when `SKILL.md` does not give you enough detail for a specific subcommand or flag.
+
+## Table of contents
+
+- [Root / build](#root--build)
+- [server](#server)
+- [new](#new)
+- [list](#list)
+- [config](#config)
+- [mod](#mod)
+- [deploy](#deploy)
+- [convert](#convert)
+- [env](#env)
+- [gen](#gen)
+- [import](#import)
+- [Global flags](#global-flags)
+
+---
+
+## Root / build
+
+Running `hugo` with no subcommand is equivalent to `hugo build`. Both build the site into `public/` (or the configured `publishDir`).
+
+Common flags:
+
+- `-D, --buildDrafts` — include drafts
+- `-F, --buildFuture` — include future-dated content
+- `-E, --buildExpired` — include expired content
+- `--minify` — minify HTML/XML/JSON/CSS/JS output
+- `-b, --baseURL <url>` — override `baseURL`
+- `-e, --environment <name>` — select environment (default `production` for `hugo`, `development` for `hugo server`)
+- `-d, --destination <path>` — where to write the build
+- `-s, --source <path>` — project root to build from
+- `-c, --contentDir <path>` — content directory override
+- `-l, --layoutDir <path>` — layout directory override
+- `-t, --theme <name>` — theme(s) to apply (repeatable / comma-separated)
+- `--themesDir <path>` — themes directory override
+- `--config <file>` — explicit config file
+- `--configDir <dir>` — explicit config dir (default `config`)
+- `--cacheDir <path>` — cache directory
+- `--ignoreCache` — skip cache
+- `--gc` — garbage-collect unused cache after build
+- `--cleanDestinationDir` — remove stale files from destination
+- `--forceSyncStatic` — copy all static files on change
+- `--noChmod`, `--noTimes` — skip syncing permission / mtimes
+- `-w, --watch` — watch and rebuild
+- `--poll <duration>` — polling-based watch (e.g., `--poll 700ms`) for filesystems without inotify/fsevents
+- `--enableGitInfo` — inject Git revision/author/date into page data
+- `--disableKinds <k1,k2>` — disable page kinds (e.g. `RSS,sitemap`)
+- `--ignoreVendorPaths <glob>` — ignore vendored modules matching the glob
+- `--noBuildLock` — skip `.hugo_build.lock`
+- `--renderSegments <names>` — render only named segments (requires `segments` config)
+- `-M, --renderToMemory` — render to RAM (mostly for `server`)
+- `--logLevel debug|info|warn|error` — log verbosity
+- `--quiet` — silence non-error output
+- `--printI18nWarnings` — surface missing translations
+- `--printPathWarnings` — surface duplicate target paths
+- `--printUnusedTemplates` — surface templates never executed
+- `--printMemoryUsage` — periodic memory stats
+- `--templateMetrics` / `--templateMetricsHints` — per-template timing and tuning hints
+- `--panicOnWarning` — convert first warning to a panic (strict mode)
+- `--clock <RFC3339>` — override "now" for deterministic builds
+- `--trace <file>` — write a Go trace (rarely useful)
+
+Production-build baseline: `hugo --minify --gc`.
+
+---
+
+## server
+
+`hugo server` (alias `hugo serve`) runs a dev webserver, watches files, and live-reloads on change. Inherits all `build` flags plus:
+
+- `-p, --port <n>` — listen port (default `1313`)
+- `--bind <addr>` — interface to bind (default `127.0.0.1`; use `0.0.0.0` for LAN)
+- `-O, --openBrowser` — open a browser on startup
+- `--appendPort` — append `:port` to `baseURL` (default true)
+- `--liveReloadPort <n>` — live-reload websocket port (for proxies/HTTPS, e.g. `443`)
+- `--disableLiveReload` — watch only, no live reload
+- `--disableFastRender` — force full re-render on changes
+- `--disableBrowserError` — suppress in-browser error overlay
+- `-N, --navigateToChanged` — auto-navigate to the edited page
+- `--noHTTPCache` — disable HTTP caching headers
+- `--renderStaticToDisk` — serve static files from disk, dynamic from memory
+- `--tlsAuto` — generate and trust a local CA certificate
+- `--tlsCertFile` / `--tlsKeyFile` — custom TLS cert/key
+- `--pprof` — expose pprof on port 8080
+
+Subcommand:
+
+- `hugo server trust` — install Hugo's local CA into the system trust store (for `--tlsAuto`)
+
+Typical authoring invocation: `hugo server -D -F` (drafts + future). Add `-O` to auto-open browser.
+
+---
+
+## new
+
+Scaffolds new content using archetypes.
+
+```
+hugo new content <path>
+```
+
+`<path>` is relative to the `content/` directory (e.g. `posts/my-post.md`). Archetypes under `archetypes/` set the front-matter template; `archetypes/default.md` is the fallback.
+
+Flags:
+
+- `-k, --kind <kind>` — force a specific archetype kind
+- `-f, --force` — overwrite existing file
+- `--editor <cmd>` — open the new file in the given editor after creation
+- `-c, --contentDir <path>` — content directory override
+
+Legacy form `hugo new <path>` (without `content`) may still work but is deprecated in favor of `hugo new content <path>`.
+
+---
+
+## list
+
+Emits CSV of content matching a filter. Useful for diagnosing why a page isn't appearing on the site.
+
+- `hugo list all` — every content file
+- `hugo list drafts` — files with `draft: true`
+- `hugo list future` — files with `date` / `publishDate` in the future
+- `hugo list expired` — files past `expiryDate`
+- `hugo list published` — everything the current build would publish
+
+Output columns: `path,slug,title,date,expiryDate,publishDate,draft,permalink`.
+
+---
+
+## config
+
+Prints the resolved, merged config.
+
+```
+hugo config                 # toml (default)
+hugo config --format yaml
+hugo config --format json
+hugo config --printZero     # include zero-valued fields
+hugo config --lang en       # single-language view
+hugo config -e production   # resolve with the `production` environment overrides
+```
+
+Subcommand:
+
+- `hugo config mounts` — print the resolved file mounts (module/theme overlays)
+
+Use this to debug config loading — especially when you suspect an environment override (`config/production/` vs `config/_default/`).
+
+---
+
+## mod
+
+Hugo Modules wrap Go modules. Requires a Go toolchain (≥1.12) and the appropriate VCS client (Git).
+
+- `hugo mod init <module-path>` — initialize the current project as a module (creates `go.mod`)
+- `hugo mod get <path>` — add or resolve a dependency
+- `hugo mod get -u ./...` — upgrade all dependencies
+- `hugo mod get -u=patch ./...` — patch-level upgrades only
+- `hugo mod tidy` — remove unused entries from `go.mod` / `go.sum`
+- `hugo mod vendor` — copy all modules into `_vendor/` (for air-gapped builds)
+- `hugo mod graph` — print the module dependency graph
+- `hugo mod verify` — verify dependencies against checksums
+- `hugo mod clean` — delete module cache for this project
+- `hugo mod npm pack` — assemble a composite `package.json` from module dependencies
+
+---
+
+## deploy
+
+Uploads `public/` to a cloud target configured in the `deployment` section of the site config (S3, GCS, Azure, etc.).
+
+Requires the `withdeploy` build tag — confirm with `hugo version`. Check the config for a `deployment.targets` section before running.
+
+Flags:
+
+- `--target <name>` — deployment target (defaults to first)
+- `--dryRun` — show what would change without uploading
+- `--confirm` — interactively confirm each change
+- `--force` — force-upload every file
+- `--invalidateCDN` — invalidate the CDN cache listed in the target (default true)
+- `--maxDeletes <n>` — cap destructive deletes (default 256, `-1` to disable)
+- `--workers <n>` — parallel upload workers (default 10)
+
+Safe default pattern: run `hugo --minify` first, then `hugo deploy --dryRun --target <name>`, show the diff, then `hugo deploy --target <name>` on explicit approval.
+
+---
+
+## convert
+
+Converts front matter in-place between formats.
+
+- `hugo convert toJSON`
+- `hugo convert toTOML`
+- `hugo convert toYAML`
+
+Flags:
+
+- `-o, --output <dir>` — write converted files to a different directory
+- `--unsafe` — allow operations without a backup (not recommended)
+
+Always commit (or back up) before running — conversion rewrites source files.
+
+---
+
+## env
+
+```
+hugo env
+```
+
+Prints Hugo's version, Go runtime, OS/arch, and build tags. First thing to check when reproducing a bug or verifying feature availability (`extended`, `withdeploy`).
+
+---
+
+## gen
+
+Generates supporting artifacts — not usually needed for authoring.
+
+- `hugo gen chromastyles --style=monokai --highlightStyle=...` — generate CSS for Chroma syntax highlighting
+- `hugo gen doc --dir <path>` — generate Markdown docs for the Hugo CLI itself
+- `hugo gen man --dir <path>` — generate man pages
+
+---
+
+## import
+
+- `hugo import jekyll <jekyll-root> <target>` — one-shot import of a Jekyll site into a new Hugo project
+
+Only Jekyll is supported out of the box.
+
+---
+
+## Global flags
+
+Available on most commands (see each command for the exact set):
+
+- `--config <file>` — explicit config file
+- `--configDir <dir>` — explicit config dir
+- `-s, --source <path>` — project root
+- `-d, --destination <path>` — build output dir
+- `-e, --environment <name>` — environment selector
+- `--logLevel debug|info|warn|error` — log verbosity
+- `--quiet` — suppress non-error output
+- `--clock <RFC3339>` — override current time
+- `--ignoreVendorPaths <glob>` — skip matching vendored modules
+- `--noBuildLock` — skip build lockfile
+- `--themesDir <path>` — themes directory override
+- `-M, --renderToMemory` — in-memory render
+
+---
+
+## Version / feature gotchas
+
+- `hugo deploy` requires `withdeploy` in the version string.
+- Image processing (`resources.ImageConfig`, WebP) requires `extended`.
+- `hugo mod` requires a Go toolchain on PATH.
+- `--renderSegments` requires a `segments` block in config; it is a no-op otherwise.
+- Config file precedence: `hugo.toml` > `hugo.yaml` > `hugo.json` (then legacy `config.*`). An explicit `--config` overrides all.
+- Environment-specific config lives at `config/<env>/hugo.<ext>` and is merged on top of `config/_default/`.


### PR DESCRIPTION
## Summary
- Restructure `.claude/CLAUDE.md` to clarify the two-file layout (global vs project), document `plugins/` as sync-overwritten, and point at `taskfile.yml` as the source of truth for format/lint
- Drop the stale `.claude/` entry from `.gitignore` — the nested dir tracks normally now
- Tighten global `CLAUDE.md` (dedupe principles, relocate Obsidian CLI note)
- Add `chore(rules)`: require a summary at the end of evaluations (`rules/verification.md`)
- Add new `hugo-cli` skill for translating plain-English Hugo requests into CLI invocations

## Test plan
- [x] `task check` passes (prettier, biome, shellcheck, ruff)
- [x] Confirm hugo-cli skill triggers correctly in a Hugo project