### PR TITLE
fix: make bash command validator advisory

### DIFF
--- a/hooks/validate-bash-commands.py
+++ b/hooks/validate-bash-commands.py
@@ -32,10 +32,10 @@ try:
 
     if warnings:
         print(
-            "BLOCKED: " + "; ".join(warnings),
+            "ADVISORY: " + "; ".join(warnings),
             file=sys.stderr,
         )
-        sys.exit(2)
+        sys.exit(0)
 
     sys.exit(0)
 


### PR DESCRIPTION
## Summary

- Change bash command validator from blocking (exit 2) to advisory (exit 0)
- Warnings still appear on stderr but no longer halt execution

## Test plan

- [ ] Trigger a bash command that would have been blocked and verify it shows ADVISORY warning but proceeds