### PR TITLE
Replace superpowers plugin with local discipline rules and skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ file-history/
 history.jsonl
 ide/
 plans/
+scratch/
 session-aliases.json
 session-data/
 session-env/

--- a/rules/code-review.md
+++ b/rules/code-review.md
@@ -1,0 +1,17 @@
+## Requesting review via subagent
+
+- Use at phase boundaries during long work, not end-of-change cleanup — for end-of-change use `review-fix`
+- Dispatch the reviewer as a subagent with a self-contained prompt; do not rely on session history leaking in
+- Include in the prompt: BASE and HEAD git SHAs, what was built, what it should do, brief description
+- Ask the subagent to return: strengths, issues by severity (Critical / Important / Minor), overall assessment
+- Act on feedback: fix Critical immediately, fix Important before proceeding, note Minor for later
+
+## Receiving feedback
+
+- No performative agreement — never "you're absolutely right!", "great point!", "thanks for catching that!", or any gratitude expression
+- Read complete feedback without reacting, then verify each item against codebase reality before implementing
+- Unclear items: stop, ask for clarification before implementing anything partial — partial understanding produces wrong implementation
+- YAGNI-check "professional" features: grep for actual usage before "implementing properly"; if unused, propose removal instead
+- Push back with technical reasoning when a suggestion breaks existing functionality, violates YAGNI, conflicts with prior architectural decisions, or the reviewer lacks full context
+- State fixes factually: "Fixed. [what changed]" — actions speak, the code shows you heard
+- When pushback turns out to be wrong: correct factually, don't over-apologize or over-explain ("You were right — checked X and it does Y. Implementing now.")

--- a/rules/debugging.md
+++ b/rules/debugging.md
@@ -1,0 +1,20 @@
+- No fixes without root cause investigation first — symptom fixes mask underlying issues
+- Read error messages and stack traces completely; they often contain the exact solution
+- Reproduce the bug consistently before proposing a fix; if not reproducible, gather more data instead of guessing
+- Check recent changes first — `git diff`, recent commits, new dependencies, config or environment changes
+- In multi-component systems (CI → build → sign, API → service → database), instrument each boundary before proposing fixes
+  - Log what data enters and exits each component
+  - Verify env/config propagation at each layer
+  - Run once to see which layer actually fails, then investigate that layer
+- Apply 5 whys to drill from immediate cause to systemic cause; stop when the answer is a design flaw, missing validation, or bad assumption
+- Find a working example of the same pattern in the same codebase and compare differences — every difference matters
+- Form one hypothesis at a time, test with the smallest possible change, verify before continuing
+- When fixing bugs, write a failing test that reproduces the bug before the fix (see `rules/testing.md`)
+- 3+ failed fixes = architectural problem, not a fix problem; stop and question the pattern rather than trying fix #4
+- Red flags that mean stop and return to root-cause investigation:
+  - "Quick fix for now, investigate later"
+  - "Just try changing X and see if it works"
+  - "It's probably X, let me fix that"
+  - Proposing solutions before tracing data flow
+  - Each fix reveals a new problem in a different place
+- User signals to watch for: "stop guessing", "ultrathink this", "is that not happening?" — all mean the approach is wrong; return to investigation

--- a/rules/model-selection.md
+++ b/rules/model-selection.md
@@ -1,3 +1,3 @@
-- When about to invoke a superpowers skill that requires deep reasoning — specifically `brainstorming`, `systematic-debugging`, `writing-plans`, or `subagent-driven-development` — check the current model from the system prompt ("You are powered by the model named..."). If not on Opus, suggest the user run `/model opus` before proceeding.
+- When about to invoke a skill that requires deep reasoning — specifically `brainstorming`, `writing-plans`, or `use-discipline` — check the current model from the system prompt ("You are powered by the model named..."). If not on Opus, suggest the user run `/model opus` before proceeding.
 - Keep the nudge brief: "This skill works best on Opus — run `/model opus` to switch."
 - Don't block on it — if the user proceeds without switching, continue normally.

--- a/rules/parallelism.md
+++ b/rules/parallelism.md
@@ -1,0 +1,11 @@
+- Dispatch parallel agents when 2+ tasks are genuinely independent — no shared state, no sequential dependencies, no chance that fixing one fixes others
+- Don't parallelize related failures, exploratory debugging where the scope is unclear, or work that touches the same files
+- Cap batches at 3-5 agents to avoid API rate limits (from `~/.claude/CLAUDE.md`)
+- Each agent gets a self-contained prompt — do not rely on session context leaking into the subagent
+- Per-agent prompt requirements:
+  - Focused scope: one file, one subsystem, one problem domain
+  - Clear goal: what counts as done
+  - Constraints: "don't change X", "fix tests only", "don't refactor production code"
+  - Explicit output format: what the agent should report back (summary of root cause + changes made)
+- After agents return: review each summary, check for file conflicts between agents, run the full suite, integrate only if clean
+- Agents can make systematic errors — spot-check their changes rather than trusting the summary

--- a/rules/testing.md
+++ b/rules/testing.md
@@ -1,0 +1,12 @@
+- Write the test first, watch it fail, write minimal code to pass
+- Watching the failure matters — it proves the test actually tests something (not a typo, not already-existing behavior)
+- A test that passes immediately after writing it is suspect; verify it was actually exercising new code
+- One behavior per test, clear name describing the behavior, real code over mocks wherever possible
+- "and" in a test name means split it — one test, one thing
+- Test name should describe the behavior, not the function ("rejects empty email" not "test submitForm")
+- Refactor only after green; no new behavior during refactor; tests stay green throughout
+- Bug fix workflow: failing test reproducing the bug → minimal fix → verify green
+- Never fix a bug without a test that would have caught it
+- Hard to test usually means hard to use — if tests need huge setup or lots of mocks, the design is the problem
+- "I'll test after" is not TDD — tests written after code pass immediately and prove nothing
+- "Manually tested" is not evidence — no record, can't re-run, forgotten under pressure

--- a/settings.json
+++ b/settings.json
@@ -466,7 +466,6 @@
     "pyright-lsp@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
-    "superpowers@superpowers-dev": true,
     "obsidian@obsidian-skills": true,
     "gh-cli@trailofbits": true,
     "modern-python@trailofbits": true
@@ -476,12 +475,6 @@
       "source": {
         "source": "github",
         "repo": "anthropics/claude-plugins-official"
-      }
-    },
-    "superpowers-dev": {
-      "source": {
-        "source": "github",
-        "repo": "obra/superpowers"
       }
     },
     "obsidian-skills": {

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: brainstorming
+description: Explores user intent, requirements, and design through conversational dig-and-advise before implementation. Use when starting creative work — features, components, architecture — where the problem space is not yet well-defined. Produces an approved design that lives in the conversation, not a committed artifact.
+---
+
+# Brainstorming
+
+Turn a rough idea into an approved design through collaborative dialogue. The goal is shared understanding before implementation, not a heavyweight deliverable.
+
+Design outputs live in the conversation. No spec file is written. When durable artifacts are needed, `writing-plans` produces them.
+
+## Process
+
+1. **Explore context first** — read recent commits, current files, relevant docs. Understand what exists before proposing what to add.
+2. **Scope check** — if the request spans multiple independent subsystems (chat + billing + analytics + auth), flag it. Don't refine details of a project that needs decomposition first. Help split into sub-projects, each with its own design cycle.
+3. **Ask clarifying questions one at a time.** Prefer multiple choice when possible. Focus on purpose, constraints, success criteria. One question per message.
+4. **Propose 2-3 approaches with tradeoffs.** Lead with a recommendation and the reasoning. Present it as something the user can redirect, not a decided plan.
+5. **Present the design in sections.** Scale each section to its complexity — a few sentences for simple parts, more for nuanced ones. Get approval after each section before moving on.
+6. **Exit on approval.** State "design approved, ready to plan" and stop. No file written.
+
+## Design principles
+
+- Break the system into small, well-bounded units with clear interfaces. Each unit has one responsibility and can be understood independently.
+- Files that change together live together. Split by responsibility, not technical layer.
+- Prefer smaller focused files over large ones doing too much.
+- In existing codebases, explore current structure first and follow established patterns. Where existing code has problems that directly affect the work, include targeted improvements — but don't propose unrelated refactoring.
+- Ruthless YAGNI. Remove unnecessary features from every design.
+
+## Scale to the problem
+
+Simple projects get short designs — a few sentences is fine. Complex projects get more detail. Don't skip the conversation for "simple" projects though — "simple" is where unexamined assumptions cause the most wasted work.
+
+## Invocation
+
+- Standalone: `brainstorming` — start from a user-provided topic
+- From `/use-discipline`: invoked after problem framing converges
+
+## What this skill does not do
+
+- No committed design doc
+- No TodoWrite per step
+- No hard gates or mandatory checklists
+- No auto-invocation of other skills
+
+When the design is approved, the user decides what comes next — `writing-plans` for durable artifacts, direct implementation for trivial changes, or further exploration.

--- a/skills/use-discipline/SKILL.md
+++ b/skills/use-discipline/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: use-discipline
+description: Primes the conversation for deep, not-yet-well-defined work by framing the arc — problem framing, brainstorming, planning, execution under rules, review via existing skills. Takes an optional topic argument to seed the problem space. Use to opt into disciplined multi-phase work rather than letting ceremony be always-on.
+argument-hint: "[topic]"
+---
+
+# Use Discipline
+
+Single opt-in entry point for deep work. Replaces the always-on ceremony of auto-injected meta-skills with an explicit primer the user invokes when they want it.
+
+## Invocation
+
+- `/use-discipline <topic>` — frames the arc around the given topic and starts dig-and-advise
+- `/use-discipline` (no argument) — ask "what are we working on?" and start dig-and-advise from the answer
+
+Never error on missing argument. The conversation is the input.
+
+## The arc
+
+This skill describes the arc. It does not enforce it. Phase transitions are conversational — suggest, wait, confirm, invoke. Never force.
+
+1. **Frame** — understand the problem space through dig-and-advise. Research tradeoffs, present 2-3 options with a clear recommendation, wait for direction. Lead with the durable option, not the expedient one.
+2. **Brainstorm** — when framing has converged enough to start exploring design, suggest moving to the `brainstorming` skill. On confirmation, invoke it.
+3. **Plan** — when a design is approved, suggest moving to the `writing-plans` skill. On confirmation, invoke it.
+4. **Execute** — after the plan is written, this skill exits. Execution is governed by the rules in `rules/` (verification, testing, debugging, parallelism, code-review, test-failures) — not by this skill.
+5. **Review** — post-execution review happens via existing local skills:
+   - `review-fix` for change-level cleanup
+   - `vc-ship` for branch finishing (atomic commits, PR)
+   - `session-review` for retrospective
+     This skill does not orchestrate review.
+
+## Not a state machine
+
+The user can skip framing and go straight to planning, or skip brainstorming if the design is already clear. The arc is a menu, not a pipeline. If the work turns out not to need this much discipline, exit early and just do it.
+
+## What this skill does not do
+
+- No ALL-CAPS directives
+- No session-start injection (opt-in only)
+- No TodoWrite per phase — phases are conversational, not tracked tasks
+- No hard gates between phases
+- No auto-committed artifacts (brainstorming outputs live in conversation; plans live in `~/.claude/scratch/plans/`)
+
+## Voice
+
+Model the terse, dig-and-advise tone the arc encourages. Ask one question at a time. Prefer multiple choice. Lead with recommendations. Wait for approval before acting on anything non-trivial.

--- a/skills/use-trueup/SKILL.md
+++ b/skills/use-trueup/SKILL.md
@@ -22,7 +22,7 @@ true-up fills the gap between "start building" and "commit." It catches choices 
 
 - Before committing, after implementation work
 - When asked "is the spec still accurate?"
-- When superpowers' 1% rule triggers on commit-related activity
+- When a commit workflow is about to run (e.g., `vc-ship`)
 
 ## Spec Discovery
 
@@ -34,8 +34,7 @@ Find the spec files to reconcile against. Check in this order:
      "spec_paths": ["docs/spec.md", "docs/design/"]
    }
    ```
-2. If `docs/superpowers/specs/` exists, use all `*.md` files in it.
-3. If neither exists, ask the user: "Where are your spec files? I need a path to check implementation decisions against."
+2. Otherwise, ask the user: "Where are your spec files? I need a path to check implementation decisions against."
 
 Store the resolved spec paths for the rest of this invocation. Do not cache across sessions.
 
@@ -150,7 +149,7 @@ Wait for the user's response before proceeding to the next decision.
 
 The sidecar stores pending and rejected decisions between invocations.
 
-**Location:** `.true-up/decisions.jsonl` relative to the resolved spec root. If specs are in `docs/superpowers/specs/`, the sidecar is `docs/superpowers/specs/.true-up/decisions.jsonl`. If specs are in a custom path from `.true-up` config, derive from the first `spec_paths` entry's parent directory.
+**Location:** `.true-up/decisions.jsonl` relative to the resolved spec root — the first `spec_paths` entry's parent directory from `.true-up` config, or the path the user provided during discovery.
 
 **Format:** One JSON object per line:
 
@@ -158,7 +157,7 @@ The sidecar stores pending and rejected decisions between invocations.
 {
   "id": "dec-<8 random hex chars>",
   "status": "pending",
-  "spec_file": "docs/superpowers/specs/2026-04-01-auth-design.md",
+  "spec_file": "docs/specs/2026-04-01-auth-design.md",
   "spec_section": "## Token Management",
   "question": "Should tokens expire on inactivity or only on logout?",
   "decision": "Tokens expire after 30 minutes of inactivity.",
@@ -189,7 +188,7 @@ The sidecar stores pending and rejected decisions between invocations.
 
 ### Gitignore
 
-On first invocation, check that the sidecar directory is in `.gitignore`. If not, append the path (e.g., `docs/superpowers/specs/.true-up/`) to `.gitignore` with a `# true-up working state` comment.
+On first invocation, check that the sidecar directory is in `.gitignore`. If not, append the path (e.g., `docs/specs/.true-up/`) to `.gitignore` with a `# true-up working state` comment.
 
 ## Commit
 
@@ -211,7 +210,7 @@ When the user asks about spec-to-test coverage, read and follow the instructions
 > /use-trueup
 
 Checking staged changes... 3 files changed.
-Reading specs from docs/superpowers/specs/...
+Reading specs from docs/specs/...
 Comparing diff against 2026-04-01-api-design.md...
 
 true-up found 2 decision(s) to review.
@@ -256,7 +255,6 @@ All decisions reviewed. Spec is up to date. Ready to commit.
 
 - Never auto-approve decisions. Every decision needs explicit user action.
 - Never edit `.claude/memory/` — design decisions belong in the spec, not in memory.
-- Never modify superpowers skill files or workflow.
 - Never write to `~/.claude/` global directories.
 - Never generate tests — flag coverage gaps only.
 - The spec must read naturally after edits. No "Decision:" prefixes, no metadata markers, no timestamps in the spec.

--- a/skills/use-trueup/references/coverage.md
+++ b/skills/use-trueup/references/coverage.md
@@ -7,8 +7,7 @@ Analyze spec-to-test coverage. Report gaps only — never generate tests.
 Use the same discovery logic as the main skill:
 
 1. If `.true-up` exists in the project root, read it as JSON and use `spec_paths`.
-2. If `docs/superpowers/specs/` exists, use all `*.md` files in it.
-3. If neither exists, ask the user where their spec files live.
+2. Otherwise, ask the user where their spec files live.
 
 ## Step 2: Extract Requirements
 

--- a/skills/vc-ship/SKILL.md
+++ b/skills/vc-ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-description: Automates git commit organization and history cleanup. Use when staging and organizing uncommitted changes into atomic commits, cleaning messy commit history, or formatting commit messages. Not for deciding what to do with a completed branch (use superpowers:finishing-a-development-branch for merge/PR/discard decisions).
+description: Automates git commit organization and history cleanup. Use when staging and organizing uncommitted changes into atomic commits, cleaning messy commit history, or formatting commit messages. Not for deciding how to integrate a completed branch.
 ---
 
 ## Reference Files

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: writing-plans
+description: Produces a bite-sized implementation plan from an approved design. Use after brainstorming or when ready to execute a multi-step task. Writes the plan to ~/.claude/scratch/plans/YYYY-MM-DD-<topic>.md as working state — never committed — and loads it back when execution starts.
+---
+
+# Writing Plans
+
+Convert an approved design into concrete bite-sized steps an engineer (or Claude) can execute without re-deriving the design.
+
+**Plans are working state, not deliverables.** Written to `~/.claude/scratch/plans/YYYY-MM-DD-<topic>.md`. Never committed. `scratch/` is gitignored.
+
+## Before writing
+
+- Read the spec or design the plan is built from
+- Map which files will be created, modified, or deleted — lock in decomposition before defining tasks
+- Each file should have one clear responsibility; prefer smaller focused files
+
+## Plan header
+
+Every plan starts with:
+
+```markdown
+# [Feature] Implementation Plan
+
+**Goal:** [One sentence]
+**Architecture:** [2-3 sentences on approach]
+**Spec:** [Path to spec file if one exists]
+**Branch:** [Branch name]
+```
+
+## Task structure
+
+Group tasks into phases. Each task has:
+
+- **Files:** exact paths for create / modify / delete
+- **Source material:** what to read before writing (if distilling from another file)
+- **Content outline or code:** enough detail to execute without re-thinking
+- **Bite-sized steps:** each step is one action (2-5 minutes), rendered as `- [ ]` checkboxes
+- **Commit step:** explicit git add + commit with commit message
+
+## No placeholders
+
+Every step contains actual content. These are plan failures — never write them:
+
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add appropriate error handling" / "add validation" / "handle edge cases"
+- "Write tests for the above" (without showing the test code)
+- "Similar to Task N" (repeat the content — tasks may be read out of order)
+- Steps that describe what to do without showing how
+- References to types, functions, or methods not defined in any task
+
+## Task granularity
+
+Each step is one action:
+
+- "Write the failing test" — step
+- "Run it and confirm it fails for the right reason" — step
+- "Implement minimal code to pass" — step
+- "Run tests and confirm green" — step
+- "Commit" — step
+
+Commands include expected output so the executor can verify.
+
+## Self-review after writing
+
+Before handing the plan off:
+
+1. **Spec coverage** — can you point to a task that implements each requirement in the spec? List gaps and add tasks.
+2. **Placeholder scan** — grep your own plan for the red-flag phrases above. Fix inline.
+3. **Type consistency** — method/function/file names referenced in later tasks match what earlier tasks defined. `clearLayers()` in Task 3 vs `clearFullLayers()` in Task 7 is a bug.
+4. **Order safety** — no task depends on a later task. Cleanups precede destructive operations so there's no broken intermediate state.
+5. **Commit atomicity** — each phase or logical group commits separately so `git bisect` stays useful.
+
+## DRY, YAGNI, TDD, frequent commits
+
+- Don't repeat content across tasks unless the executor might read them out of order (then repeat)
+- Don't plan speculative features
+- Tests come before implementation (see `rules/testing.md`)
+- Commit at each phase boundary at minimum
+
+## Execution handoff
+
+After saving the plan:
+
+1. Confirm the file path to the user
+2. Offer to review before executing
+3. On approval, execute inline — no ceremonial "which mode would you like" prompt. If the user wants parallel subagents, they'll ask.

--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: writing-skills
+description: Scaffolds new skills using Anthropic's skill-creator with local conventions overlaid — naming prefixes, third-person description voice, 500-line target, rename protocol. Use when creating, renaming, or restructuring a skill in this repository.
+---
+
+# Writing Skills
+
+Thin wrapper over `skill-creator:skill-creator`. Delegates scaffolding and structure to the upstream skill; adds this repository's conventions.
+
+## When to use
+
+- Creating a new skill in `skills/`
+- Renaming an existing skill
+- Restructuring a skill that has grown past 500 lines and needs reference files
+
+For the mechanics of skill creation (directory layout, frontmatter, progressive disclosure), invoke `skill-creator:skill-creator` and follow its guidance. This file tracks only the local overrides.
+
+## Local conventions
+
+### Naming
+
+- Directory names are kebab-case, lowercase, max 64 chars
+- Prefixes:
+  - `cc-` — Claude Code meta-tools (release review, automation recommender, etc.)
+  - `vc-` — version control workflows
+  - `md-` — CLAUDE.md operations
+  - No prefix — general-purpose skills
+- The `name:` frontmatter field defaults to the directory name if omitted; prefer omitting unless the name needs to differ
+
+### Frontmatter
+
+- Only `description` is required; all other fields are optional
+- Description uses third-person voice ("Analyzes..." not "Analyze...")
+- Three-part description pattern: **[What it does]. Use when [triggers]. [Key capabilities].**
+- Target 200-500 chars for the description
+- Include `argument-hint:` if the skill takes a slash-command argument
+
+### Structure
+
+- Target SKILL.md under 500 lines; push depth into supporting files
+- Reference files over 100 lines should include a `## Contents` TOC
+- Supporting files live as `skills/<name>/references/<file>.md` or similar
+
+### Voice
+
+- Terse, plain prose
+- No ALL-CAPS directives, no "HARD-GATE" framing, no "EXTREMELY IMPORTANT" language
+- Present process as flow, not as rigid gates
+- Match the tone of existing skills in this repo (see `use-trueup`, `vc-ship`, `review-fix`)
+
+## Rename protocol
+
+When renaming a skill:
+
+1. `mv skills/<old> skills/<new>`
+2. Update `name:` in SKILL.md frontmatter if present, or remove it (defaults to directory name)
+3. Grep for stale references: `grep -r "<old-name>" --include="*.md" --include="*.json"`
+4. Update every reference: README, skill groups, `settings.json`, cross-skill refs
+5. Check `settings.local.json` for stale entries (not tracked in git, easy to miss)
+6. Grep again to verify zero results remain
+
+## After creating or modifying a skill
+
+- Run `task check` or `bunx prettier --write skills/<name>/SKILL.md` to format
+- Run `/cc-review` to validate structure and catch issues
+- Add a one-line entry to memory if the skill has a non-obvious purpose worth recalling across sessions


### PR DESCRIPTION
## Summary

- Replaces the `superpowers-dev` plugin with local rules and skills tuned to established preferences
- Adds four always-on rule files: `debugging.md`, `testing.md`, `parallelism.md`, `code-review.md` — distilled from the corresponding superpowers skills without the ceremonial framing
- Adds four invokable skills: `brainstorming`, `writing-plans`, `writing-skills`, `use-discipline`
- `/use-discipline` is the new keystone: a single opt-in primer for deep work that frames the arc (problem framing → brainstorm → plan → execute under rules → review via existing skills), replacing the always-on session-start injection
- Removes the `superpowers-dev` plugin entirely — marketplace, cache, enablement, and every dangling reference
- Drops `scratch/` from git (gitignored) so in-flight specs and plans never get committed

## Design notes

- **Discipline skills → rules.** Systematic debugging, TDD, parallel agents, and code review are always-on concerns. Folding them into `rules/*.md` removes the ceremony of "invoke this skill before doing X" while keeping the substance auto-loaded into every session.
- **Workflow skills stay as skills.** `brainstorming` and `writing-plans` are phase-gated and invokable. Local versions are terser than the superpowers originals: no hard gates, no ALL-CAPS directives, no TodoWrite-per-step ceremony, no auto-committed artifacts.
- **`writing-skills` wraps `skill-creator:skill-creator`.** Anthropic's skill-creator handles scaffolding; the local wrapper overlays naming prefixes, voice rules, the rename protocol, and this repo's conventions.
- **Plans live in `~/.claude/scratch/plans/`, not the repo.** Working state, not a deliverable.

## Test plan

- [x] New session after the changes does not load the `<EXTREMELY_IMPORTANT>` using-superpowers preamble
- [x] All four new skills (`brainstorming`, `writing-plans`, `writing-skills`, `use-discipline`) appear in the harness skill listing
- [x] All four new rules (`debugging.md`, `testing.md`, `parallelism.md`, `code-review.md`) auto-load into the system prompt
- [x] `grep -r "superpowers" .claude/` returns zero hits
- [x] `bunx biome check settings.json` passes
- [x] `bunx prettier --write` on all new files leaves them unchanged
- [x] Pre-existing uncommitted work in the branch was preserved untouched through the scope of this change