### PR TITLE
polish: apply /cc-review P4/P5 fixes to new skills and rules

### DIFF
--- a/rules/parallelism.md
+++ b/rules/parallelism.md
@@ -1,6 +1,6 @@
 - Dispatch parallel agents when 2+ tasks are genuinely independent — no shared state, no sequential dependencies, no chance that fixing one fixes others
 - Don't parallelize related failures, exploratory debugging where the scope is unclear, or work that touches the same files
-- Cap batches at 3-5 agents to avoid API rate limits (from `~/.claude/CLAUDE.md`)
+- Cap batches at 3-5 parallel agents to avoid API rate limits; queue the rest
 - Each agent gets a self-contained prompt — do not rely on session context leaking into the subagent
 - Per-agent prompt requirements:
   - Focused scope: one file, one subsystem, one problem domain

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -32,7 +32,7 @@ Simple projects get short designs — a few sentences is fine. Complex projects 
 
 ## Invocation
 
-- Standalone: `brainstorming` — start from a user-provided topic
+- Standalone: `/brainstorming` — start from a user-provided topic
 - From `/use-discipline`: invoked after problem framing converges
 
 ## What this skill does not do

--- a/skills/use-discipline/SKILL.md
+++ b/skills/use-discipline/SKILL.md
@@ -27,7 +27,8 @@ This skill describes the arc. It does not enforce it. Phase transitions are conv
    - `review-fix` for change-level cleanup
    - `vc-ship` for branch finishing (atomic commits, PR)
    - `session-review` for retrospective
-     This skill does not orchestrate review.
+
+This skill does not orchestrate review.
 
 ## Not a state machine
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -14,6 +14,7 @@ Convert an approved design into concrete bite-sized steps an engineer (or Claude
 - Read the spec or design the plan is built from
 - Map which files will be created, modified, or deleted — lock in decomposition before defining tasks
 - Each file should have one clear responsibility; prefer smaller focused files
+- Save the plan to `~/.claude/scratch/plans/YYYY-MM-DD-<topic>.md` — date-prefix so multiple plans sort chronologically; `scratch/` is gitignored so the file never ships
 
 ## Plan header
 


### PR DESCRIPTION
## Summary

Four small polish fixes surfaced by `/cc-review` on the recent discipline skills and rules. No behavior changes — readability, consistency, and self-containment.

- **brainstorming** — standalone invocation prefixed with slash for consistency with `/use-discipline`
- **writing-plans** — date-prefix path convention mirrored from description into "Before writing" body so it's discoverable when the body is read standalone
- **parallelism** — agent-cap rationale inlined; drops the self-reference to `~/.claude/CLAUDE.md` since this file is itself loaded from `~/.claude/rules/`
- **use-discipline** — blank line added before "This skill does not orchestrate review" so it no longer visually attaches to the `session-review` bullet

## Test plan

- [x] prettier-clean
- [x] `/cc-review` surfaced these as P4/P5 items
- [x] Cross-references (`skill-creator:skill-creator`, `session-review`, `review-fix`, `vc-ship`, `rules/testing.md`) still resolve