### PR TITLE
Tune event-log signal: drop noise, enrich the rest

### DIFF
--- a/hooks/log-event.sh
+++ b/hooks/log-event.sh
@@ -39,7 +39,38 @@ SubagentStart)
 PostToolUseFailure)
 	tool=$(echo "$input" | jq -r '.tool_name // empty' 2>/dev/null) || true
 	err=$(echo "$input" | jq -r '.error // empty' 2>/dev/null | head -1 | cut -c1-100) || true
-	[[ -n "$tool" ]] && detail="$tool: $err" || detail="$err"
+	cmd=""
+	if [[ $tool == "Bash" ]]; then
+		cmd=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null | head -1 | cut -c1-60) || true
+	fi
+	if [[ -n "$tool" && -n "$cmd" ]]; then
+		detail="$tool [$cmd]: $err"
+	elif [[ -n "$tool" ]]; then
+		detail="$tool: $err"
+	else
+		detail="$err"
+	fi
+	;;
+PermissionRequest)
+	tool=$(echo "$input" | jq -r '.tool_name // empty' 2>/dev/null) || true
+	target=""
+	case "$tool" in
+	Bash)
+		target=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null | head -1 | cut -c1-60) || true
+		;;
+	Write | Edit | Read | NotebookEdit)
+		target=$(echo "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || true
+		target=${target##*/}
+		;;
+	esac
+	suggest=$(echo "$input" | jq -r '.permission_suggestions[0].type // empty' 2>/dev/null) || true
+	if [[ -n "$tool" && -n "$target" && -n "$suggest" ]]; then
+		detail="$tool [$target] ($suggest)"
+	elif [[ -n "$tool" && -n "$target" ]]; then
+		detail="$tool [$target]"
+	elif [[ -n "$tool" ]]; then
+		detail="$tool"
+	fi
 	;;
 PreCompact | PostCompact)
 	detail=$(echo "$input" | jq -r '.trigger // empty' 2>/dev/null) || true

--- a/settings.json
+++ b/settings.json
@@ -119,35 +119,6 @@
             "type": "command",
             "command": "HOOK_EVENT=SessionStart ~/.claude/hooks/suggest-compact.sh",
             "timeout": 5
-          },
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/log-event.sh",
-            "timeout": 5,
-            "async": true
-          }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/log-event.sh",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/log-event.sh",
-            "timeout": 5,
-            "async": true
           }
         ]
       }
@@ -289,18 +260,6 @@
         ]
       }
     ],
-    "Notification": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/log-event.sh",
-            "timeout": 5,
-            "async": true
-          }
-        ]
-      }
-    ],
     "ConfigChange": [
       {
         "hooks": [
@@ -422,18 +381,6 @@
       }
     ],
     "Setup": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/log-event.sh",
-            "timeout": 5,
-            "async": true
-          }
-        ]
-      }
-    ],
-    "CwdChanged": [
       {
         "hooks": [
           {


### PR DESCRIPTION
## Summary

- Drop `log-event.sh` from 5 hooks (SessionStart, SessionEnd, UserPromptSubmit, Notification, CwdChanged) — they logged only timestamps, producing ~57% of log volume as noise.
- Enrich `PostToolUseFailure` for Bash with the failing command stem (first 60 chars).
- Add `PermissionRequest` case: tool name + target (command for Bash, basename for file tools) + first permission suggestion type — makes the log useful for tuning the allowlist.

## Test plan

- [x] `shfmt` + `shellcheck` clean on `hooks/log-event.sh`
- [x] Synthetic payload smoke tests for both enriched events produce expected output
- [x] Live recon verified field names (`tool_input.command`, `tool_input.file_path`, `permission_suggestions[0].type`)
- [x] Settings validate with `jq` + `biome format`