### PR TITLE
feat(pdf): render reference PDFs via typst+pandoc tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ debug/
 file-history/
 history.jsonl
 ide/
+pdf/out/
 plans/
 scratch/
 session-env/

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ mcp-needs-auth-cache.json
 node_modules/
 paste-cache/
 .ruff_cache/
+.task/
 __pycache__/
 *.pyc
 skills/.marketplace/

--- a/pdf/assemble-annotated.sh
+++ b/pdf/assemble-annotated.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Emit assembled markdown for the Annotated PDF style to stdout.
+# shellcheck disable=SC2016  # backticks in printf format strings are literal markdown
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# Extract a frontmatter field value from a markdown file.
+# Usage: frontmatter_field <file> <field>
+# Returns empty string if file has no frontmatter or field is absent.
+frontmatter_field() {
+	local file="$1"
+	local field="$2"
+	awk -v field="$field" '
+    BEGIN { in_fm = 0; found = "" }
+    NR == 1 && /^---[[:space:]]*$/ { in_fm = 1; next }
+    in_fm && /^---[[:space:]]*$/ { in_fm = 0; exit }
+    in_fm {
+      if (match($0, "^"field":[[:space:]]*")) {
+        val = substr($0, RLENGTH + 1)
+        gsub(/^["'\'']|["'\'']$/, "", val)
+        found = val
+        exit
+      }
+    }
+    END { print found }
+  ' "$file"
+}
+
+# Print the first non-empty paragraph of the body (skipping frontmatter).
+first_paragraph() {
+	local file="$1"
+	awk '
+    BEGIN { in_fm = 0; past_fm = 0; para = "" }
+    NR == 1 && /^---[[:space:]]*$/ { in_fm = 1; next }
+    in_fm && /^---[[:space:]]*$/ { in_fm = 0; past_fm = 1; next }
+    in_fm { next }
+    !past_fm { past_fm = 1 }
+    past_fm && /^#/ { next }
+    past_fm && NF == 0 { if (para != "") exit; next }
+    past_fm { para = (para == "" ? $0 : para " " $0) }
+    END { print para }
+  ' "$file"
+}
+
+emit_full() {
+	local path="$1"
+	local fence="${2:-}"
+	printf '\n## `%s`\n\n' "$path"
+	if [[ -n "$fence" ]]; then
+		printf '```%s\n' "$fence"
+		cat "$path"
+		printf '\n```\n'
+	else
+		cat "$path"
+		printf '\n'
+	fi
+}
+
+printf '# Top-level documents\n'
+for f in README.md THEORY.md CLAUDE.md; do
+	[[ -f "$f" ]] && emit_full "$f"
+done
+
+printf '\n# Settings\n'
+emit_full "settings.json" "json"
+
+printf '\n# Rules\n\n'
+printf 'Auto-loaded into every session as global user instructions.\n\n'
+for f in rules/*.md; do
+	emit_full "$f"
+done
+
+printf '\n# Skills\n\n'
+for d in skills/*/; do
+	d="${d%/}"
+	name="$(basename "$d")"
+	if [[ -f "$d/SKILL.md" ]]; then
+		f="$d/SKILL.md"
+		suffix=""
+	elif [[ -f "$d/SKILL.md-off" ]]; then
+		f="$d/SKILL.md-off"
+		suffix=" _(disabled)_"
+	else
+		continue
+	fi
+	desc="$(frontmatter_field "$f" description)"
+	summary="$(first_paragraph "$f")"
+	printf '\n### %s%s\n\n' "$name" "$suffix"
+	[[ -n "$desc" ]] && printf '**Description:** %s\n\n' "$desc"
+	[[ -n "$summary" ]] && printf '%s\n' "$summary"
+done
+
+printf '\n# Agents\n\n'
+for f in agents/*.md; do
+	name="$(basename "$f" .md)"
+	desc="$(frontmatter_field "$f" description)"
+	summary="$(first_paragraph "$f")"
+	printf '\n### %s\n\n' "$name"
+	[[ -n "$desc" ]] && printf '**Description:** %s\n\n' "$desc"
+	[[ -n "$summary" ]] && printf '%s\n' "$summary"
+done
+
+printf '\n# Hooks\n\n'
+printf 'Hook scripts triggered by lifecycle events. Wiring lives in `settings.json`.\n\n'
+for f in hooks/*; do
+	[[ -f "$f" ]] || continue
+	name="$(basename "$f")"
+	printf '\n### %s\n\n' "$name"
+	# Print the first non-shebang comment line as a one-line synopsis if present.
+	synopsis="$(awk 'NR==1 && /^#!/ {next} /^#/ {sub(/^#[[:space:]]*/, ""); print; exit} !/^#/ {exit}' "$f")"
+	[[ -n "$synopsis" ]] && printf '%s\n' "$synopsis"
+done

--- a/pdf/assemble-curated.sh
+++ b/pdf/assemble-curated.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Emit assembled markdown for the Curated PDF style to stdout.
+# Hand-written tour of the configuration with selective full-file inclusions.
+# shellcheck disable=SC2016  # backticks in printf format strings are literal markdown
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+emit_file() {
+	local path="$1"
+	local fence="${2:-}"
+	if [[ -n "$fence" ]]; then
+		printf '```%s\n' "$fence"
+		cat "$path"
+		printf '\n```\n'
+	else
+		cat "$path"
+		printf '\n'
+	fi
+}
+
+extract_desc() {
+	awk '
+    BEGIN { in_fm = 0 }
+    NR == 1 && /^---[[:space:]]*$/ { in_fm = 1; next }
+    in_fm && /^---[[:space:]]*$/ { exit }
+    in_fm && /^description:/ {
+      sub(/^description:[[:space:]]*/, "")
+      gsub(/^["'\'']|["'\'']$/, "")
+      print
+      exit
+    }
+  ' "$1"
+}
+
+cat <<'EOF'
+# Overview
+
+This document is a curated tour of the `~/.claude/` directory — the customization layer that shapes how Claude Code behaves across every project. It pulls together the high-level theory, the explicit instructions, the settings, the rule files, the skills, the hooks, and the agents into a single readable narrative.
+
+The two top-level documents below set the philosophy and the practical orientation.
+
+EOF
+
+emit_file "THEORY.md"
+emit_file "README.md"
+
+cat <<'EOF'
+
+# Top-level Instructions
+
+`CLAUDE.md` is the global user instructions file: it's auto-loaded into every project as part of the system context. It's where principles, collaboration style, and workflow expectations live.
+
+EOF
+
+emit_file "CLAUDE.md"
+
+cat <<'EOF'
+
+# Settings
+
+`settings.json` configures the Claude Code harness: environment variables, permission allowlists, lifecycle hook wiring, and the status-line command. It is the single most consequential file in this directory.
+
+EOF
+
+emit_file "settings.json" "json"
+
+cat <<'EOF'
+
+# Rules
+
+Every `.md` file in `rules/` is auto-loaded as a global user instruction on every session. They are organized by topic (one file per language/tool/concern) so guidance can be scoped and updated without one giant file.
+
+`core.md` is the foundational rule file — quoted in full below as the canonical example.
+
+EOF
+
+emit_file "rules/core.md"
+
+cat <<'EOF'
+
+The remaining rule files cover specific tools and concerns:
+
+EOF
+
+for f in rules/*.md; do
+	name="$(basename "$f" .md)"
+	[[ "$name" == "core" ]] && continue
+	printf -- '- `%s` — %s\n' "$name" "$(awk 'NR==1 && /^# / { sub(/^# /, ""); print; exit } /^[^#]/ && NF { print; exit }' "$f")"
+done
+
+cat <<'EOF'
+
+# Skills
+
+Skills are auto-detected workflows. Each one lives in `skills/<name>/SKILL.md` with optional supporting files. The skill's frontmatter `description:` controls when Claude triggers it.
+
+A representative sampling, quoted in full:
+
+EOF
+
+# Three representative skills, chosen to span categories.
+for skill in cc-review walkthrough last30days; do
+	if [[ -f "skills/$skill/SKILL.md" ]]; then
+		printf '\n## `skills/%s/SKILL.md`\n\n' "$skill"
+		emit_file "skills/$skill/SKILL.md"
+	fi
+done
+
+cat <<'EOF'
+
+The remaining skills (disabled skills are marked):
+
+EOF
+
+for d in skills/*/; do
+	d="${d%/}"
+	name="$(basename "$d")"
+	case "$name" in
+	cc-review | walkthrough | last30days) continue ;;
+	esac
+	if [[ -f "$d/SKILL.md" ]]; then
+		desc="$(extract_desc "$d/SKILL.md")"
+		printf -- '- `%s` — %s\n' "$name" "${desc:-(no description)}"
+	elif [[ -f "$d/SKILL.md-off" ]]; then
+		desc="$(extract_desc "$d/SKILL.md-off")"
+		printf -- '- `%s` _(disabled)_ — %s\n' "$name" "${desc:-(no description)}"
+	fi
+done
+
+cat <<'EOF'
+
+# Hooks
+
+Hooks are scripts in `hooks/` invoked at lifecycle events (PreToolUse, PostToolUse, SessionStart, Stop, etc.). The wiring — which event triggers which script — lives in `settings.json` (already quoted above).
+
+A representative hook, quoted in full:
+
+EOF
+
+if [[ -f "hooks/log-event.sh" ]]; then
+	printf '\n## `hooks/log-event.sh`\n\n'
+	emit_file "hooks/log-event.sh" "bash"
+fi
+
+cat <<'EOF'
+
+The remaining hooks:
+
+EOF
+
+for f in hooks/*; do
+	[[ -f "$f" ]] || continue
+	name="$(basename "$f")"
+	[[ "$name" == "log-event.sh" ]] && continue
+	synopsis="$(awk 'NR==1 && /^#!/ {next} /^#/ {sub(/^#[[:space:]]*/, ""); print; exit} !/^#/ {exit}' "$f")"
+	printf -- '- `%s` — %s\n' "$name" "${synopsis:-(no synopsis)}"
+done
+
+cat <<'EOF'
+
+# Agents
+
+Subagent definitions live in `agents/<name>.md`. They're invoked via the Task tool or automatically when the description matches.
+
+EOF
+
+for f in agents/*.md; do
+	name="$(basename "$f" .md)"
+	printf '\n## `agents/%s.md`\n\n' "$name"
+	emit_file "$f"
+done

--- a/pdf/assemble-full.sh
+++ b/pdf/assemble-full.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Emit assembled markdown for the Full PDF style to stdout.
+# shellcheck disable=SC2016  # backticks in printf format strings are literal markdown
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+emit_file() {
+	local path="$1"
+	local fence="${2:-}"
+	printf '\n## `%s`\n\n' "$path"
+	if [[ -n "$fence" ]]; then
+		printf '```%s\n' "$fence"
+		cat "$path"
+		printf '\n```\n'
+	else
+		cat "$path"
+		printf '\n'
+	fi
+}
+
+ext_to_fence() {
+	case "$1" in
+	*.sh) echo "bash" ;;
+	*.py) echo "python" ;;
+	*.js) echo "javascript" ;;
+	*) echo "text" ;;
+	esac
+}
+
+printf '# Top-level documents\n'
+for f in README.md THEORY.md CLAUDE.md; do
+	[[ -f "$f" ]] && emit_file "$f"
+done
+
+printf '\n# Settings\n'
+emit_file "settings.json" "json"
+
+printf '\n# Rules\n'
+for f in rules/*.md; do
+	emit_file "$f"
+done
+
+printf '\n# Skills\n'
+for d in skills/*/; do
+	d="${d%/}"
+	if [[ -f "$d/SKILL.md" ]]; then
+		emit_file "$d/SKILL.md"
+	elif [[ -f "$d/SKILL.md-off" ]]; then
+		printf '\n## `%s/SKILL.md-off` _(disabled)_\n\n' "$d"
+		cat "$d/SKILL.md-off"
+		printf '\n'
+	fi
+done
+
+printf '\n# Agents\n'
+for f in agents/*.md; do
+	emit_file "$f"
+done
+
+printf '\n# Hooks\n'
+for f in hooks/*; do
+	[[ -f "$f" ]] || continue
+	fence="$(ext_to_fence "$f")"
+	emit_file "$f" "$fence"
+done

--- a/pdf/pandoc-annotated.yaml
+++ b/pdf/pandoc-annotated.yaml
@@ -1,7 +1,9 @@
-from: markdown
+from: markdown-citations
 to: pdf
 pdf-engine: typst
 template: pdf/template.typ
+filters:
+  - pdf/strip-internal-links.lua
 toc: true
 toc-depth: 2
 number-sections: false

--- a/pdf/pandoc-annotated.yaml
+++ b/pdf/pandoc-annotated.yaml
@@ -1,0 +1,17 @@
+from: markdown
+to: pdf
+pdf-engine: typst
+template: pdf/template.typ
+toc: true
+toc-depth: 2
+number-sections: false
+metadata:
+  title: "Claude Code Configuration — Annotated Index"
+  subtitle: "~/.claude on 2026-04-25"
+  author: "Mark Ayers"
+variables:
+  papersize: us-letter
+  fontsize: 10pt
+  mainfont: "New York"
+  monofont: "SF NS Mono"
+  sansfont: "SF NS"

--- a/pdf/pandoc-curated.yaml
+++ b/pdf/pandoc-curated.yaml
@@ -1,7 +1,9 @@
-from: markdown
+from: markdown-citations
 to: pdf
 pdf-engine: typst
 template: pdf/template.typ
+filters:
+  - pdf/strip-internal-links.lua
 toc: true
 toc-depth: 2
 number-sections: false

--- a/pdf/pandoc-curated.yaml
+++ b/pdf/pandoc-curated.yaml
@@ -1,0 +1,17 @@
+from: markdown
+to: pdf
+pdf-engine: typst
+template: pdf/template.typ
+toc: true
+toc-depth: 2
+number-sections: false
+metadata:
+  title: "Claude Code Configuration — Curated Snapshot"
+  subtitle: "~/.claude on 2026-04-25"
+  author: "Mark Ayers"
+variables:
+  papersize: us-letter
+  fontsize: 10pt
+  mainfont: "New York"
+  monofont: "SF NS Mono"
+  sansfont: "SF NS"

--- a/pdf/pandoc-full.yaml
+++ b/pdf/pandoc-full.yaml
@@ -1,0 +1,17 @@
+from: markdown
+to: pdf
+pdf-engine: typst
+template: pdf/template.typ
+toc: true
+toc-depth: 3
+number-sections: true
+metadata:
+  title: "Claude Code Configuration — Full Reference"
+  subtitle: "~/.claude on 2026-04-25"
+  author: "Mark Ayers"
+variables:
+  papersize: us-letter
+  fontsize: 10pt
+  mainfont: "New York"
+  monofont: "SF NS Mono"
+  sansfont: "SF NS"

--- a/pdf/pandoc-full.yaml
+++ b/pdf/pandoc-full.yaml
@@ -1,7 +1,9 @@
-from: markdown
+from: markdown-citations
 to: pdf
 pdf-engine: typst
 template: pdf/template.typ
+filters:
+  - pdf/strip-internal-links.lua
 toc: true
 toc-depth: 3
 number-sections: true

--- a/pdf/strip-internal-links.lua
+++ b/pdf/strip-internal-links.lua
@@ -1,0 +1,10 @@
+-- Convert internal anchor links ([text](#anchor)) to plain text.
+-- The assembled markdown concatenates many source files; cross-references
+-- written for one file may not resolve in the combined document. Typst
+-- errors on unresolved labels, so render them as plain text instead.
+function Link(el)
+  if el.target:sub(1, 1) == "#" then
+    return el.content
+  end
+  return el
+end

--- a/pdf/template.typ
+++ b/pdf/template.typ
@@ -1,0 +1,200 @@
+#let horizontalrule = line(start: (25%,0%), end: (75%,0%))
+
+#show terms.item: it => block(breakable: false)[
+  #text(weight: "bold")[#it.term]
+  #block(inset: (left: 1.5em, top: -0.4em))[#it.description]
+]
+
+#set table(
+  inset: 6pt,
+  stroke: none
+)
+
+#show figure.where(
+  kind: table
+): set figure.caption(position: $if(table-caption-position)$$table-caption-position$$else$top$endif$)
+
+#show figure.where(
+  kind: image
+): set figure.caption(position: $if(figure-caption-position)$$figure-caption-position$$else$bottom$endif$)
+
+$if(highlighting-definitions)$
+// syntax highlighting functions from skylighting:
+$highlighting-definitions$
+
+$endif$
+$if(template)$
+#import "$template$": conf
+$else$
+$template.typst()$
+$endif$
+
+$if(smart)$
+$else$
+#set smartquote(enabled: false)
+
+$endif$
+$for(header-includes)$
+$header-includes$
+
+$endfor$
+#show: doc => conf(
+$if(title)$
+  title: [$title$],
+$endif$
+$if(subtitle)$
+  subtitle: [$subtitle$],
+$endif$
+$if(author)$
+  authors: (
+$for(author)$
+$if(author.name)$
+    ( name: [$author.name$],
+      affiliation: [$author.affiliation$],
+      email: [$author.email$] ),
+$else$
+    ( name: [$author$],
+      affiliation: "",
+      email: "" ),
+$endif$
+$endfor$
+    ),
+$endif$
+$if(keywords)$
+  keywords: ($for(keywords)$$keywords$$sep$,$endfor$),
+$endif$
+$if(date)$
+  date: [$date$],
+$endif$
+$if(lang)$
+  lang: "$lang$",
+$endif$
+$if(region)$
+  region: "$region$",
+$endif$
+$if(abstract-title)$
+  abstract-title: [$abstract-title$],
+$endif$
+$if(abstract)$
+  abstract: [$abstract$],
+$endif$
+$if(thanks)$
+  thanks: [$thanks$],
+$endif$
+$if(margin)$
+  margin: ($for(margin/pairs)$$margin.key$: $margin.value$,$endfor$),
+$endif$
+$if(papersize)$
+  paper: "$papersize$",
+$endif$
+$if(mainfont)$
+  font: ("$mainfont$",),
+$endif$
+$if(fontsize)$
+  fontsize: $fontsize$,
+$endif$
+$if(mathfont)$
+  mathfont: ($for(mathfont)$"$mathfont$",$endfor$),
+$endif$
+$if(codefont)$
+  codefont: ($for(codefont)$"$codefont$",$endfor$),
+$endif$
+$if(linestretch)$
+  linestretch: $linestretch$,
+$endif$
+$if(section-numbering)$
+  sectionnumbering: "$section-numbering$",
+$endif$
+  pagenumbering: $if(page-numbering)$"$page-numbering$"$else$none$endif$,
+$if(linkcolor)$
+  linkcolor: [$linkcolor$],
+$endif$
+$if(citecolor)$
+  citecolor: [$citecolor$],
+$endif$
+$if(filecolor)$
+  filecolor: [$filecolor$],
+$endif$
+  cols: $if(columns)$$columns$$else$1$endif$,
+  doc,
+)
+
+// --- Custom template tweaks ---
+$if(subtitle)$
+#set page(
+  paper: "us-letter",
+  margin: (x: 0.85in, y: 1.0in),
+  header: align(right)[
+    #text(size: 8pt, fill: gray)[
+      $subtitle$
+    ]
+  ],
+)
+$else$
+$if(title)$
+#set page(
+  paper: "us-letter",
+  margin: (x: 0.85in, y: 1.0in),
+  header: align(right)[
+    #text(size: 8pt, fill: gray)[
+      $title$
+    ]
+  ],
+)
+$else$
+#set page(
+  paper: "us-letter",
+  margin: (x: 0.85in, y: 1.0in),
+)
+$endif$
+$endif$
+
+#show raw.where(block: true): block.with(
+  fill: rgb("#f5f5f5"),
+  inset: 8pt,
+  radius: 3pt,
+  width: 100%,
+)
+#show raw: set text(font: "SF NS Mono", size: 9pt)
+
+#set text(
+  font: "New York",
+  size: 10pt,
+  lang: "en",
+)
+#show heading: set text(font: "SF NS", weight: "semibold")
+// --- End custom tweaks ---
+
+$for(include-before)$
+$include-before$
+
+$endfor$
+$if(toc)$
+#outline(
+  title: auto,
+  depth: $toc-depth$
+);
+$endif$
+
+$body$
+
+$if(citations)$
+$for(nocite-ids)$
+#cite(label("${it}"), form: none)
+$endfor$
+$if(csl)$
+
+#set bibliography(style: "$csl$")
+$elseif(bibliographystyle)$
+
+#set bibliography(style: "$bibliographystyle$")
+$endif$
+$if(bibliography)$
+
+#bibliography(($for(bibliography)$"$bibliography$"$sep$,$endfor$)$if(full-bibliography)$, full: true$endif$)
+$endif$
+$endif$
+$for(include-after)$
+
+$include-after$
+$endfor$

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -81,6 +81,34 @@ tasks:
     cmds:
       - uvx ruff check hooks/*.py
 
+  pdf:curated:
+    desc: Build curated-snapshot PDF
+    cmds:
+      - mkdir -p pdf/out
+      - pdf/assemble-curated.sh > pdf/out/curated.md
+      - pandoc --defaults pdf/pandoc-curated.yaml pdf/out/curated.md -o pdf/out/cc-config-curated.pdf
+      - test -s pdf/out/cc-config-curated.pdf
+    sources:
+      - rules/core.md
+      - skills/cc-review/SKILL.md
+      - skills/last30days/SKILL.md
+      - skills/walkthrough/SKILL.md
+      - skills/*/SKILL.md
+      - skills/*/SKILL.md-off
+      - hooks/log-event.sh
+      - hooks/*
+      - agents/*.md
+      - settings.json
+      - CLAUDE.md
+      - THEORY.md
+      - README.md
+      - pdf/assemble-curated.sh
+      - pdf/pandoc-curated.yaml
+      - pdf/template.typ
+      - pdf/strip-internal-links.lua
+    generates:
+      - pdf/out/cc-config-curated.pdf
+
   pdf:annotated:
     desc: Build annotated-index PDF
     cmds:

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -81,6 +81,30 @@ tasks:
     cmds:
       - uvx ruff check hooks/*.py
 
+  pdf:annotated:
+    desc: Build annotated-index PDF
+    cmds:
+      - mkdir -p pdf/out
+      - pdf/assemble-annotated.sh > pdf/out/annotated.md
+      - pandoc --defaults pdf/pandoc-annotated.yaml pdf/out/annotated.md -o pdf/out/cc-config-annotated.pdf
+      - test -s pdf/out/cc-config-annotated.pdf
+    sources:
+      - rules/*.md
+      - skills/*/SKILL.md
+      - skills/*/SKILL.md-off
+      - agents/*.md
+      - hooks/*
+      - settings.json
+      - CLAUDE.md
+      - THEORY.md
+      - README.md
+      - pdf/assemble-annotated.sh
+      - pdf/pandoc-annotated.yaml
+      - pdf/template.typ
+      - pdf/strip-internal-links.lua
+    generates:
+      - pdf/out/cc-config-annotated.pdf
+
   pdf:full:
     desc: Build full-reference PDF
     cmds:

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -80,3 +80,27 @@ tasks:
     desc: Lint Python files with ruff
     cmds:
       - uvx ruff check hooks/*.py
+
+  pdf:full:
+    desc: Build full-reference PDF
+    cmds:
+      - mkdir -p pdf/out
+      - pdf/assemble-full.sh > pdf/out/full.md
+      - pandoc --defaults pdf/pandoc-full.yaml pdf/out/full.md -o pdf/out/cc-config-full.pdf
+      - test -s pdf/out/cc-config-full.pdf
+    sources:
+      - rules/*.md
+      - skills/*/SKILL.md
+      - skills/*/SKILL.md-off
+      - agents/*.md
+      - hooks/*
+      - settings.json
+      - CLAUDE.md
+      - THEORY.md
+      - README.md
+      - pdf/assemble-full.sh
+      - pdf/pandoc-full.yaml
+      - pdf/template.typ
+      - pdf/strip-internal-links.lua
+    generates:
+      - pdf/out/cc-config-full.pdf

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -1,14 +1,14 @@
 version: "3"
 
 # Scope notes:
-# - Shell and Python linters target `hooks/*.sh` and `hooks/*.py` only,
-#   because hooks/ is the only location that holds authored .sh / .py files
-#   in this repo (all other .sh / .py under ~/.claude/ is runtime-generated
-#   or belongs to plugins and is gitignored).
+# - Shell linters target `hooks/*.sh` and `pdf/*.sh`. Python linters target
+#   `hooks/*.py`. These are the only locations that hold authored .sh / .py
+#   files in this repo (all other .sh / .py under ~/.claude/ is runtime-
+#   generated or belongs to plugins and is gitignored).
 # - Markdown formatting spans the whole repo via prettier, honoring .gitignore.
 # - JSON formatting targets top-level *.json only (settings.json, biome.json).
-# - If .sh, .py, .go, or .ts files are ever added outside hooks/, extend the
-#   corresponding task's glob rather than relying on implicit scope.
+# - If .sh, .py, .go, or .ts files are ever added outside hooks/ or pdf/,
+#   extend the corresponding task's glob rather than relying on implicit scope.
 
 tasks:
   default:
@@ -41,6 +41,13 @@ tasks:
       - task: lint:sh
       - task: lint:py
 
+  pdf:
+    desc: Build all three configuration PDFs
+    cmds:
+      - task: pdf:full
+      - task: pdf:annotated
+      - task: pdf:curated
+
   format:md:
     desc: Format markdown files with prettier
     cmds:
@@ -54,7 +61,7 @@ tasks:
   format:sh:
     desc: Format shell scripts with shfmt
     cmds:
-      - shfmt -w hooks/*.sh
+      - shfmt -w hooks/*.sh pdf/*.sh
 
   format:py:
     desc: Format Python files with ruff
@@ -74,12 +81,60 @@ tasks:
   lint:sh:
     desc: Lint shell scripts with shellcheck
     cmds:
-      - shellcheck hooks/*.sh
+      - shellcheck hooks/*.sh pdf/*.sh
 
   lint:py:
     desc: Lint Python files with ruff
     cmds:
       - uvx ruff check hooks/*.py
+
+  pdf:full:
+    desc: Build full-reference PDF
+    cmds:
+      - mkdir -p pdf/out
+      - pdf/assemble-full.sh > pdf/out/full.md
+      - pandoc --defaults pdf/pandoc-full.yaml pdf/out/full.md -o pdf/out/cc-config-full.pdf
+      - test -s pdf/out/cc-config-full.pdf
+    sources:
+      - rules/*.md
+      - skills/*/SKILL.md
+      - skills/*/SKILL.md-off
+      - agents/*.md
+      - hooks/*
+      - settings.json
+      - CLAUDE.md
+      - THEORY.md
+      - README.md
+      - pdf/assemble-full.sh
+      - pdf/pandoc-full.yaml
+      - pdf/template.typ
+      - pdf/strip-internal-links.lua
+    generates:
+      - pdf/out/cc-config-full.pdf
+
+  pdf:annotated:
+    desc: Build annotated-index PDF
+    cmds:
+      - mkdir -p pdf/out
+      - pdf/assemble-annotated.sh > pdf/out/annotated.md
+      - pandoc --defaults pdf/pandoc-annotated.yaml pdf/out/annotated.md -o pdf/out/cc-config-annotated.pdf
+      - test -s pdf/out/cc-config-annotated.pdf
+    sources:
+      - rules/*.md
+      - skills/*/SKILL.md
+      - skills/*/SKILL.md-off
+      - agents/*.md
+      - hooks/*
+      - settings.json
+      - CLAUDE.md
+      - THEORY.md
+      - README.md
+      - pdf/assemble-annotated.sh
+      - pdf/pandoc-annotated.yaml
+      - pdf/template.typ
+      - pdf/strip-internal-links.lua
+    generates:
+      - pdf/out/cc-config-annotated.pdf
 
   pdf:curated:
     desc: Build curated-snapshot PDF
@@ -109,50 +164,7 @@ tasks:
     generates:
       - pdf/out/cc-config-curated.pdf
 
-  pdf:annotated:
-    desc: Build annotated-index PDF
+  pdf:clean:
+    desc: Remove generated PDF artifacts
     cmds:
-      - mkdir -p pdf/out
-      - pdf/assemble-annotated.sh > pdf/out/annotated.md
-      - pandoc --defaults pdf/pandoc-annotated.yaml pdf/out/annotated.md -o pdf/out/cc-config-annotated.pdf
-      - test -s pdf/out/cc-config-annotated.pdf
-    sources:
-      - rules/*.md
-      - skills/*/SKILL.md
-      - skills/*/SKILL.md-off
-      - agents/*.md
-      - hooks/*
-      - settings.json
-      - CLAUDE.md
-      - THEORY.md
-      - README.md
-      - pdf/assemble-annotated.sh
-      - pdf/pandoc-annotated.yaml
-      - pdf/template.typ
-      - pdf/strip-internal-links.lua
-    generates:
-      - pdf/out/cc-config-annotated.pdf
-
-  pdf:full:
-    desc: Build full-reference PDF
-    cmds:
-      - mkdir -p pdf/out
-      - pdf/assemble-full.sh > pdf/out/full.md
-      - pandoc --defaults pdf/pandoc-full.yaml pdf/out/full.md -o pdf/out/cc-config-full.pdf
-      - test -s pdf/out/cc-config-full.pdf
-    sources:
-      - rules/*.md
-      - skills/*/SKILL.md
-      - skills/*/SKILL.md-off
-      - agents/*.md
-      - hooks/*
-      - settings.json
-      - CLAUDE.md
-      - THEORY.md
-      - README.md
-      - pdf/assemble-full.sh
-      - pdf/pandoc-full.yaml
-      - pdf/template.typ
-      - pdf/strip-internal-links.lua
-    generates:
-      - pdf/out/cc-config-full.pdf
+      - rm -rf pdf/out


### PR DESCRIPTION
## Summary

Adds three render styles for the rules/skills/CLAUDE.md content as reference PDFs, driven by `go-task`:

- `task pdf:full` — full reference (every rule + skill SKILL.md, full text)
- `task pdf:annotated` — annotated index: top-level docs (README, THEORY, CLAUDE), `settings.json`, and `rules/*.md` rendered in full; skills rendered as one-line summaries (frontmatter `description` + first paragraph)
- `task pdf:curated` — curated snapshot (selected items, narrative form)
- `task pdf:clean` — drop generated artifacts under `pdf/out/`
- `task pdf` — parent task that runs all three builds

## What's here

- `pdf/template.typ` — shared typst template (uses macOS system fonts: New York, SF NS, SF NS Mono)
- `pdf/pandoc-{full,annotated,curated}.yaml` — pandoc defaults files per style
- `pdf/strip-internal-links.lua` — pandoc Lua filter to drop unresolved-anchor links before typst rendering
- `pdf/assemble-{full,annotated,curated}.sh` — assembly scripts wired into the taskfile (covered by `task lint:sh`)
- `taskfile.yml` — adds the `pdf:*` tasks
- `.gitignore` — ignores `.task/` (go-task checksum cache); `pdf/out/` was already ignored

## Test plan

- [ ] `task pdf:full` produces a non-empty PDF in `pdf/out/`
- [ ] `task pdf:annotated` produces a non-empty PDF in `pdf/out/`
- [ ] `task pdf:curated` produces a non-empty PDF in `pdf/out/`
- [ ] `task pdf` runs all three end-to-end
- [ ] `task pdf:clean` removes `pdf/out/`
- [ ] `task check` passes (incl. `lint:sh` covering `pdf/*.sh`)